### PR TITLE
Feat#32 마이페이지 조회 기능

### DIFF
--- a/src/main/java/team9/ddang/member/controller/MemberController.java
+++ b/src/main/java/team9/ddang/member/controller/MemberController.java
@@ -14,6 +14,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import team9.ddang.global.api.ApiResponse;
 import team9.ddang.member.controller.request.JoinRequest;
+import team9.ddang.member.entity.IsMatched;
 import team9.ddang.member.entity.Member;
 import team9.ddang.member.oauth2.CustomOAuth2User;
 import team9.ddang.member.service.MemberService;
@@ -178,14 +179,14 @@ public class MemberController {
     }
 
 
-    @GetMapping("/{memberId}")
+    @GetMapping("/mypage")
     @Operation(
-            summary = "멤버 정보 조회",
-            description = "특정 멤버의 정보를 조회합니다.",
+            summary = "회원 정보 조회",
+            description = "회원 정보를 조회합니다.",
             responses = {
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "200",
-                            description = "멤버 정보 조회 성공",
+                            description = "회원 정보 조회 성공",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = MyPageResponse.class)
@@ -193,7 +194,7 @@ public class MemberController {
                     ),
                     @io.swagger.v3.oas.annotations.responses.ApiResponse(
                             responseCode = "400",
-                            description = "멤버 정보 조회 실패",
+                            description = "회원 정보 조회 실패",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = ApiResponse.class)
@@ -217,8 +218,65 @@ public class MemberController {
                     )
             }
     )
-    public ApiResponse<MyPageResponse> getMemberInfo(@PathVariable Long memberId) {
+    public ApiResponse<MyPageResponse> getMemberInfo(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
 
+        Long memberId = customOAuth2User.getMember().getMemberId();
         return ApiResponse.ok(memberService.getMemberInfo(memberId));
+    }
+
+    @PatchMapping
+    @Operation(
+            summary = "강번따 허용 여부 수정",
+            description = "강번따 허용 여부를 수정합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "강번따 허용 여부",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = IsMatched.class)
+                    )
+            ),
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "강번따 허용 여부 수정 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class)
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "강번따 허용 여부 수정 실패",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class)
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "401",
+                            description = "인증 실패",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class)
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "500",
+                            description = "서버 오류",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class)
+                            )
+                    )
+            }
+    )
+    public ApiResponse<IsMatched> updateIsMatched(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+            @RequestParam IsMatched isMatched) {
+
+        Long memberId = customOAuth2User.getMember().getMemberId();
+        IsMatched updatedIsMatched = memberService.updateIsMatched(memberId, isMatched);
+        return ApiResponse.ok(updatedIsMatched);
     }
 }

--- a/src/main/java/team9/ddang/member/controller/MemberController.java
+++ b/src/main/java/team9/ddang/member/controller/MemberController.java
@@ -10,11 +10,15 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import team9.ddang.global.api.ApiResponse;
 import team9.ddang.member.controller.request.JoinRequest;
+import team9.ddang.member.entity.Member;
+import team9.ddang.member.oauth2.CustomOAuth2User;
 import team9.ddang.member.service.MemberService;
 import team9.ddang.member.service.response.MemberResponse;
+import team9.ddang.member.service.response.MyPageResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -172,5 +176,49 @@ public class MemberController {
         log.info("logout() 메서드 진입");
         return ApiResponse.ok(memberService.logout(request));
     }
-}
 
+
+    @GetMapping("/{memberId}")
+    @Operation(
+            summary = "멤버 정보 조회",
+            description = "특정 멤버의 정보를 조회합니다.",
+            responses = {
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "200",
+                            description = "멤버 정보 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = MyPageResponse.class)
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "400",
+                            description = "멤버 정보 조회 실패",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class)
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "401",
+                            description = "인증 실패",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class)
+                            )
+                    ),
+                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                            responseCode = "500",
+                            description = "서버 오류",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ApiResponse.class)
+                            )
+                    )
+            }
+    )
+    public ApiResponse<MyPageResponse> getMemberInfo(@PathVariable Long memberId) {
+
+        return ApiResponse.ok(memberService.getMemberInfo(memberId));
+    }
+}

--- a/src/main/java/team9/ddang/member/entity/Member.java
+++ b/src/main/java/team9/ddang/member/entity/Member.java
@@ -58,7 +58,8 @@ public class Member extends BaseEntity {
     private Role role;
 
     @Builder
-    private Member(String name, String email, LocalDate birthDate, Gender gender, String address, FamilyRole familyRole, Provider provider, String profileImg, IsMatched isMatched, Family family, Role role) {
+    private Member(Long memberId, String name, String email, LocalDate birthDate, Gender gender, String address, FamilyRole familyRole, Provider provider, String profileImg, IsMatched isMatched, Family family, Role role) {
+        this.memberId = memberId;
         this.name = name;
         this.email = email;
         this.birthDate = birthDate;
@@ -70,5 +71,9 @@ public class Member extends BaseEntity {
         this.isMatched = isMatched;
         this.family = family;
         this.role = role;
+    }
+
+    public void updateIsMatched(IsMatched isMatched) {
+        this.isMatched = isMatched;
     }
 }

--- a/src/main/java/team9/ddang/member/jwt/filter/JwtAuthenticationProcessingFilter.java
+++ b/src/main/java/team9/ddang/member/jwt/filter/JwtAuthenticationProcessingFilter.java
@@ -1,16 +1,19 @@
 package team9.ddang.member.jwt.filter;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.filter.OncePerRequestFilter;
+import team9.ddang.global.api.ApiResponse;
 import team9.ddang.member.entity.Member;
 import team9.ddang.member.jwt.service.JwtService;
 import team9.ddang.member.oauth2.CustomOAuth2User;
@@ -50,8 +53,7 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
         }
 
         // AccessToken이 유효하지 않으면 클라이언트에 401 응답 전송
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().write("AccessToken is invalid");
+        sendErrorResponse(response, HttpStatus.UNAUTHORIZED, "AccessToken is invalid");
     }
 
     private void checkAccessTokenAndAuthentication(String accessToken, FilterChain filterChain, HttpServletRequest request, HttpServletResponse response) throws ServletException, IOException {
@@ -83,6 +85,19 @@ public class JwtAuthenticationProcessingFilter extends OncePerRequestFilter {
     private boolean isExcludedUrl(String requestURI) {
         return EXCLUDED_URLS.stream().anyMatch(requestURI::startsWith);
     }
+
+
+    private void sendErrorResponse(HttpServletResponse response, HttpStatus status, String message) throws IOException {
+        response.setStatus(status.value());
+        response.setContentType("application/json");
+        response.setCharacterEncoding("UTF-8");
+
+        ApiResponse<Object> apiResponse = new ApiResponse<>(status, message, null);
+        String jsonResponse = new ObjectMapper().writeValueAsString(apiResponse); // JSON 변환
+
+        response.getWriter().write(jsonResponse);
+    }
+
 }
 
 

--- a/src/main/java/team9/ddang/member/repository/WalkWithMemberRepository.java
+++ b/src/main/java/team9/ddang/member/repository/WalkWithMemberRepository.java
@@ -1,7 +1,16 @@
 package team9.ddang.member.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team9.ddang.member.entity.WalkWithMember;
 
 public interface WalkWithMemberRepository extends JpaRepository<WalkWithMember, Long> {
+
+    @Query("""
+            SELECT COALESCE(COUNT(w), 0) 
+            FROM WalkWithMember w 
+            WHERE w.sender.memberId = :memberId
+            """)
+    int countBySenderMemberId(@Param("memberId") Long memberId);
 }

--- a/src/main/java/team9/ddang/member/service/MemberService.java
+++ b/src/main/java/team9/ddang/member/service/MemberService.java
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import team9.ddang.member.service.request.JoinServiceRequest;
 import team9.ddang.member.service.response.MemberResponse;
+import team9.ddang.member.service.response.MyPageResponse;
 
 public interface MemberService {
 
@@ -12,4 +13,6 @@ public interface MemberService {
     String reissueAccessToken(HttpServletRequest request, HttpServletResponse response);
 
     String logout(HttpServletRequest request);
+
+    MyPageResponse getMemberInfo(Long memberId);
 }

--- a/src/main/java/team9/ddang/member/service/MemberService.java
+++ b/src/main/java/team9/ddang/member/service/MemberService.java
@@ -2,6 +2,7 @@ package team9.ddang.member.service;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import team9.ddang.member.entity.IsMatched;
 import team9.ddang.member.service.request.JoinServiceRequest;
 import team9.ddang.member.service.response.MemberResponse;
 import team9.ddang.member.service.response.MyPageResponse;
@@ -15,4 +16,6 @@ public interface MemberService {
     String logout(HttpServletRequest request);
 
     MyPageResponse getMemberInfo(Long memberId);
+
+    IsMatched updateIsMatched(Long memberId, IsMatched isMatched);
 }

--- a/src/main/java/team9/ddang/member/service/MemberServiceImpl.java
+++ b/src/main/java/team9/ddang/member/service/MemberServiceImpl.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team9.ddang.member.entity.IsMatched;
 import team9.ddang.member.entity.Member;
 import team9.ddang.member.jwt.service.JwtService;
 import team9.ddang.member.repository.MemberRepository;
@@ -87,6 +88,7 @@ public class MemberServiceImpl implements MemberService {
         return "Success Logout";
     }
 
+    @Transactional(readOnly = true)
     @Override
     public MyPageResponse getMemberInfo(Long memberId) {
 
@@ -101,5 +103,14 @@ public class MemberServiceImpl implements MemberService {
         int countWalksWithMember = walkWithMemberRepository.countBySenderMemberId(memberId);
 
         return MyPageResponse.from(member, totalDistanceInKilometers, countWalks, countWalksWithMember);
+    }
+
+    @Override
+    public IsMatched updateIsMatched(Long memberId, IsMatched isMatched) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        member.updateIsMatched(isMatched);
+        return member.getIsMatched(); // 업데이트된 값을 반환
     }
 }

--- a/src/main/java/team9/ddang/member/service/MemberServiceImpl.java
+++ b/src/main/java/team9/ddang/member/service/MemberServiceImpl.java
@@ -9,8 +9,11 @@ import org.springframework.transaction.annotation.Transactional;
 import team9.ddang.member.entity.Member;
 import team9.ddang.member.jwt.service.JwtService;
 import team9.ddang.member.repository.MemberRepository;
+import team9.ddang.member.repository.WalkWithMemberRepository;
 import team9.ddang.member.service.request.JoinServiceRequest;
 import team9.ddang.member.service.response.MemberResponse;
+import team9.ddang.member.service.response.MyPageResponse;
+import team9.ddang.walk.repository.WalkRepository;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +22,8 @@ import team9.ddang.member.service.response.MemberResponse;
 public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
+    private final WalkRepository walkRepository;
+    private final WalkWithMemberRepository walkWithMemberRepository;
     private final JwtService jwtService;
 
     @Override
@@ -80,5 +85,21 @@ public class MemberServiceImpl implements MemberService {
         }
 
         return "Success Logout";
+    }
+
+    @Override
+    public MyPageResponse getMemberInfo(Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+
+        int totalDistanceInMeters = walkRepository.findTotalDistanceByMemberId(memberId);
+        int countWalks = walkRepository.countWalksByMemberId(memberId);
+
+        double totalDistanceInKilometers = totalDistanceInMeters / 1000.0;
+
+        int countWalksWithMember = walkWithMemberRepository.countBySenderMemberId(memberId);
+
+        return MyPageResponse.from(member, totalDistanceInKilometers, countWalks, countWalksWithMember);
     }
 }

--- a/src/main/java/team9/ddang/member/service/response/MemberResponse.java
+++ b/src/main/java/team9/ddang/member/service/response/MemberResponse.java
@@ -1,5 +1,6 @@
 package team9.ddang.member.service.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import team9.ddang.global.entity.Gender;
 import team9.ddang.member.entity.FamilyRole;
 import team9.ddang.member.entity.Member;
@@ -7,15 +8,33 @@ import team9.ddang.member.entity.Provider;
 
 import java.time.LocalDate;
 
+@Schema(description = "회원 응답 데이터")
 public record MemberResponse(
+        @Schema(description = "회원 ID", example = "1")
         Long memberId,
+
+        @Schema(description = "회원 이름", example = "John Doe")
         String name,
+
+        @Schema(description = "회원 이메일", example = "john.doe@example.com")
         String email,
+
+        @Schema(description = "OAuth2 제공자", example = "GOOGLE")
         Provider provider,
+
+        @Schema(description = "회원 생년월일", example = "1990-01-01")
         LocalDate birthDate,
+
+        @Schema(description = "회원 성별", example = "MALE")
         Gender gender,
+
+        @Schema(description = "회원 주소", example = "123 Main Street")
         String address,
+
+        @Schema(description = "가족 내 역할", example = "FATHER")
         FamilyRole familyRole,
+
+        @Schema(description = "회원 프로필 이미지 URL", example = "https://example.com/profile.jpg")
         String profileImg
 ) {
     public static MemberResponse from(Member member) {

--- a/src/main/java/team9/ddang/member/service/response/MyPageResponse.java
+++ b/src/main/java/team9/ddang/member/service/response/MyPageResponse.java
@@ -3,6 +3,7 @@ package team9.ddang.member.service.response;
 import io.swagger.v3.oas.annotations.media.Schema;
 import team9.ddang.global.entity.Gender;
 import team9.ddang.member.entity.FamilyRole;
+import team9.ddang.member.entity.IsMatched;
 import team9.ddang.member.entity.Member;
 
 @Schema(description = "마이페이지 응답 데이터")
@@ -22,6 +23,12 @@ public record MyPageResponse(
         @Schema(description = "가족 내 역할", example = "FATHER")
         FamilyRole familyRole,
 
+        @Schema(description = "회원 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String profileImg,
+
+        @Schema(description = "강번따 허용 여부", example = "TRUE")
+        IsMatched isMatched,
+
         @Schema(description = "총 산책 거리 (킬로미터)", example = "12.5")
         double totalDistance,
 
@@ -38,6 +45,8 @@ public record MyPageResponse(
                 member.getAddress(),
                 member.getGender(),
                 member.getFamilyRole(),
+                member.getProfileImg(),
+                member.getIsMatched(),
                 totalDistance,
                 walkCount,
                 countWalksWithMember

--- a/src/main/java/team9/ddang/member/service/response/MyPageResponse.java
+++ b/src/main/java/team9/ddang/member/service/response/MyPageResponse.java
@@ -1,0 +1,46 @@
+package team9.ddang.member.service.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team9.ddang.global.entity.Gender;
+import team9.ddang.member.entity.FamilyRole;
+import team9.ddang.member.entity.Member;
+
+@Schema(description = "마이페이지 응답 데이터")
+public record MyPageResponse(
+        @Schema(description = "회원 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "회원 이름", example = "John Doe")
+        String name,
+
+        @Schema(description = "회원 주소", example = "123 Main Street")
+        String address,
+
+        @Schema(description = "회원 성별", example = "MALE")
+        Gender gender,
+
+        @Schema(description = "가족 내 역할", example = "FATHER")
+        FamilyRole familyRole,
+
+        @Schema(description = "총 산책 거리 (킬로미터)", example = "12.5")
+        double totalDistance,
+
+        @Schema(description = "총 산책 횟수", example = "5")
+        int walkCount,
+
+        @Schema(description = "강번따 횟수", example = "3")
+        int countWalksWithMember
+) {
+    public static MyPageResponse from(Member member, double totalDistance, int walkCount, int countWalksWithMember) {
+        return new MyPageResponse(
+                member.getMemberId(),
+                member.getName(),
+                member.getAddress(),
+                member.getGender(),
+                member.getFamilyRole(),
+                totalDistance,
+                walkCount,
+                countWalksWithMember
+        );
+    }
+}

--- a/src/main/java/team9/ddang/walk/repository/WalkRepository.java
+++ b/src/main/java/team9/ddang/walk/repository/WalkRepository.java
@@ -1,7 +1,23 @@
 package team9.ddang.walk.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import team9.ddang.walk.entity.Walk;
 
 public interface WalkRepository extends JpaRepository<Walk, Long> {
+
+    @Query("""
+            SELECT COALESCE(SUM(w.totalDistance), 0)
+            FROM Walk w
+            WHERE w.member.memberId = :memberId
+            """)
+    int findTotalDistanceByMemberId(@Param("memberId") Long memberId);
+
+    @Query("""
+            SELECT COALESCE(COUNT(w), 0) 
+            FROM Walk w 
+            WHERE w.member.memberId = :memberId
+            """)
+    int countWalksByMemberId(@Param("memberId") Long memberId);
 }

--- a/src/test/java/team9/ddang/chat/repository/ChatRepositoryTest.java
+++ b/src/test/java/team9/ddang/chat/repository/ChatRepositoryTest.java
@@ -49,7 +49,7 @@ class ChatRepositoryTest extends IntegrationTestSupport {
                 .gender(Gender.MALE)
                 .provider(Provider.GOOGLE)
 //                .role(Role.ROLE_USER)
-                .comment("안녕하세요")
+//                .comment("안녕하세요")
                 .isMatched(IsMatched.TRUE)
                 .build());
 
@@ -90,7 +90,7 @@ class ChatRepositoryTest extends IntegrationTestSupport {
                 .gender(Gender.MALE)
                 .provider(Provider.GOOGLE)
 //                .role(Role.ROLE_USER)
-                .comment("안녕하세요")
+//                .comment("안녕하세요")
                 .isMatched(IsMatched.TRUE)
                 .build());
 

--- a/src/test/java/team9/ddang/member/controller/MemberControllerTest.java
+++ b/src/test/java/team9/ddang/member/controller/MemberControllerTest.java
@@ -9,17 +9,24 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.support.WithMockUser;
 import team9.ddang.ApiTestSupport;
 import team9.ddang.member.controller.request.JoinRequest;
 import team9.ddang.global.entity.Gender;
 import team9.ddang.member.entity.FamilyRole;
+import team9.ddang.member.entity.IsMatched;
+import team9.ddang.member.entity.Member;
+import team9.ddang.member.oauth2.CustomOAuth2User;
 import team9.ddang.member.repository.MemberRepository;
 import team9.ddang.member.service.MemberService;
 import team9.ddang.member.service.response.MemberResponse;
 import team9.ddang.member.service.response.MyPageResponse;
 
 import java.time.LocalDate;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -84,12 +91,31 @@ class MemberControllerTest extends ApiTestSupport {
         // Given
         Long memberId = 1L;
 
+        // Mock된 사용자 설정
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(
+                Collections.emptySet(),
+                Map.of("email", "user@example.com"),
+                "email",
+                Member.builder()
+                        .memberId(memberId)
+                        .name("John Doe")
+                        .email("user@example.com")
+                        .isMatched(IsMatched.TRUE)
+                        .build()
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities())
+        );
+
         MyPageResponse myPageResponse = new MyPageResponse(
                 memberId,
                 "John Doe",
                 "123 Test Street",
                 Gender.MALE,
                 FamilyRole.FATHER,
+                "https://example.com/profile.jpg",
+                IsMatched.TRUE,
                 12.5,
                 5,
                 3
@@ -98,7 +124,7 @@ class MemberControllerTest extends ApiTestSupport {
         when(memberService.getMemberInfo(memberId)).thenReturn(myPageResponse);
 
         // When & Then
-        mockMvc.perform(get("/api/v1/member/{memberId}", memberId)
+        mockMvc.perform(get("/api/v1/member/mypage")
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer test-access-token"))
                 .andExpect(status().isOk())
@@ -107,8 +133,55 @@ class MemberControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.address").value("123 Test Street"))
                 .andExpect(jsonPath("$.data.gender").value("MALE"))
                 .andExpect(jsonPath("$.data.familyRole").value("FATHER"))
+                .andExpect(jsonPath("$.data.profileImg").value("https://example.com/profile.jpg"))
+                .andExpect(jsonPath("$.data.isMatched").value("TRUE"))
                 .andExpect(jsonPath("$.data.totalDistance").value(12.5))
                 .andExpect(jsonPath("$.data.walkCount").value(5))
                 .andExpect(jsonPath("$.data.countWalksWithMember").value(3));
+    }
+
+
+    @DisplayName("강번따 허용 여부 수정 - 성공")
+    @Test
+    @WithMockUser(roles = "USER")
+        // Mock 사용자를 설정
+    void updateIsMatched() throws Exception {
+        // Given
+        Long memberId = 1L; // 인증된 사용자의 ID
+        IsMatched isMatched = IsMatched.TRUE; // 요청 값
+        IsMatched updatedIsMatched = IsMatched.TRUE; // Mock된 반환 값
+
+        // Mock된 사용자 설정
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(
+                Collections.emptySet(),
+                Map.of("email", "user@example.com"),
+                "email",
+                Member.builder()
+                        .memberId(memberId)
+                        .name("John Doe")
+                        .email("user@example.com")
+                        .isMatched(IsMatched.FALSE) // 기존 상태
+                        .build()
+        );
+
+        // SecurityContext에 Mock 사용자 설정
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities())
+        );
+
+        String accessToken = jwtService.createAccessToken("user@example.com", "GOOGLE");
+
+        when(memberService.updateIsMatched(memberId, isMatched)).thenReturn(updatedIsMatched);
+
+        // When & Then
+        mockMvc.perform(patch("/api/v1/member")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .param("isMatched", isMatched.name())
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").value(isMatched.name()))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"));
     }
 }

--- a/src/test/java/team9/ddang/member/controller/MemberControllerTest.java
+++ b/src/test/java/team9/ddang/member/controller/MemberControllerTest.java
@@ -13,9 +13,11 @@ import org.springframework.security.test.context.support.WithMockUser;
 import team9.ddang.ApiTestSupport;
 import team9.ddang.member.controller.request.JoinRequest;
 import team9.ddang.global.entity.Gender;
+import team9.ddang.member.entity.FamilyRole;
 import team9.ddang.member.repository.MemberRepository;
 import team9.ddang.member.service.MemberService;
 import team9.ddang.member.service.response.MemberResponse;
+import team9.ddang.member.service.response.MyPageResponse;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -73,5 +75,40 @@ class MemberControllerTest extends ApiTestSupport {
                 .andExpect(jsonPath("$.data.name").value("John Doe"))
                 .andExpect(jsonPath("$.data.email").value("guest@example.com"))
                 .andExpect(jsonPath("$.data.birthDate").value("1990-01-01"));
+    }
+
+    @DisplayName("마이페이지 - 회원 정보 조회 성공")
+    @Test
+    @WithMockUser(roles = "USER")
+    void getMemberInfo() throws Exception {
+        // Given
+        Long memberId = 1L;
+
+        MyPageResponse myPageResponse = new MyPageResponse(
+                memberId,
+                "John Doe",
+                "123 Test Street",
+                Gender.MALE,
+                FamilyRole.FATHER,
+                12.5,
+                5,
+                3
+        );
+
+        when(memberService.getMemberInfo(memberId)).thenReturn(myPageResponse);
+
+        // When & Then
+        mockMvc.perform(get("/api/v1/member/{memberId}", memberId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer test-access-token"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.memberId").value(memberId))
+                .andExpect(jsonPath("$.data.name").value("John Doe"))
+                .andExpect(jsonPath("$.data.address").value("123 Test Street"))
+                .andExpect(jsonPath("$.data.gender").value("MALE"))
+                .andExpect(jsonPath("$.data.familyRole").value("FATHER"))
+                .andExpect(jsonPath("$.data.totalDistance").value(12.5))
+                .andExpect(jsonPath("$.data.walkCount").value(5))
+                .andExpect(jsonPath("$.data.countWalksWithMember").value(3));
     }
 }


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- 멤버 정보, 총 산책 횟수, 총 산책 거리, 총 강번따 횟수를 조회하는 기능입니다.
- 강번따 설정 변경 기능도 함께 구현했습니다.


## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #32 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
- 이슈 주제에 벗어나긴 하지만 기존에 인증 실패하였을 때 401 응답이 String으로 넘어오는 것을 확인하여 JSON으로 넘겨주도록 수정하였습니다. (JwtAuthenticationProcessingFilter 클래스)
- 누락되어있었던 강번따 설정 변경 기능을 2차 푸시하여 추가했습니다.
