### PR TITLE
[Feat/#24 친구 기능 개발]

### DIFF
--- a/src/main/java/team9/ddang/member/controller/FriendController.java
+++ b/src/main/java/team9/ddang/member/controller/FriendController.java
@@ -1,0 +1,139 @@
+package team9.ddang.member.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import team9.ddang.global.api.ApiResponse;
+import team9.ddang.member.controller.request.AddFriendRequest;
+import team9.ddang.member.oauth2.CustomOAuth2User;
+import team9.ddang.member.service.FriendService;
+import team9.ddang.member.service.response.FriendListResponse;
+import team9.ddang.member.service.response.FriendResponse;
+import team9.ddang.member.service.response.MemberResponse;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/friend")
+@Tag(name = "Friend API", description = "친구 관련 API")
+@Slf4j
+public class FriendController {
+
+    private final FriendService friendService;
+
+
+    @Operation(
+            summary = "친구 추가",
+            description = "친구 추가 요청을 보냅니다. 상대도 이미 보냈으면 친구 추가를 진행합니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    description = "친구를 추가하고자 하는 멤버의 ID",
+                    required = true,
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = AddFriendRequest.class)
+                    )
+            ),
+            parameters = {
+                    @Parameter(
+                            name = "Authorization",
+                            description = "액세스 토큰",
+                            required = true,
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(type = "string", example = "Bearer eyJhbGciOiJIUzI1...")
+                    )
+            }
+    )
+    @PostMapping("")
+    public ApiResponse<MemberResponse> addFriend(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+                                                 @RequestBody @Valid AddFriendRequest addFriendRequest){
+
+        MemberResponse response = friendService.addFriend(customOAuth2User.getMember(), addFriendRequest);
+        return ApiResponse.ok(response);
+    }
+
+
+    @Operation(
+            summary = "친구 리스트 조회",
+            description = "친구인 멤버들의 리스트를 조회 합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "Authorization",
+                            description = "액세스 토큰",
+                            required = true,
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(type = "string", example = "Bearer eyJhbGciOiJIUzI1...")
+                    )
+            }
+    )
+    @GetMapping("")
+    public ApiResponse<List<FriendListResponse> > getFriendList(@AuthenticationPrincipal CustomOAuth2User customOAuth2User){
+
+        List<FriendListResponse> response = friendService.getFriendList(customOAuth2User.getMember());
+        return ApiResponse.ok(response);
+    }
+
+    @Operation(
+            summary = "친구 상세 조회",
+            description = "친구의 프로필을 상세 조회합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "Authorization",
+                            description = "액세스 토큰",
+                            required = true,
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(type = "string", example = "Bearer eyJhbGciOiJIUzI1...")
+                    ),
+                    @Parameter(
+                            name = "memberId",
+                            description = "멤버 ID",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            schema = @Schema(type = "long", example = "12345")
+                    )
+            }
+    )
+    @GetMapping("/{memberId}")
+    public ApiResponse<FriendResponse> getFriend(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+                                    @PathVariable(value = "memberId") Long memberId){
+
+        FriendResponse response = friendService.getFriend(customOAuth2User.getMember() ,memberId);
+        return ApiResponse.ok(response);
+    }
+
+    @Operation(
+            summary = "친구 삭제",
+            description = "친구를 삭제합니다.",
+            parameters = {
+                    @Parameter(
+                            name = "Authorization",
+                            description = "액세스 토큰",
+                            required = true,
+                            in = ParameterIn.HEADER,
+                            schema = @Schema(type = "string", example = "Bearer eyJhbGciOiJIUzI1...")
+                    ),
+                    @Parameter(
+                            name = "memberId",
+                            description = "멤버 ID",
+                            required = true,
+                            in = ParameterIn.PATH,
+                            schema = @Schema(type = "long", example = "12345")
+                    )
+            }
+    )
+    @DeleteMapping("/{memberId}")
+    public ApiResponse<Void> deleteFriend(@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+                                       @PathVariable(value = "memberId") Long memberId){
+
+        friendService.deleteFriend(customOAuth2User.getMember() ,memberId);
+        return ApiResponse.noContent();
+    }
+}

--- a/src/main/java/team9/ddang/member/controller/request/AddFriendRequest.java
+++ b/src/main/java/team9/ddang/member/controller/request/AddFriendRequest.java
@@ -1,0 +1,13 @@
+package team9.ddang.member.controller.request;
+
+import jakarta.validation.constraints.NotNull;
+import team9.ddang.member.service.request.AddFriendServiceRequest;
+
+public record AddFriendRequest(
+        @NotNull(message = "memberId 는 필수 값 입니다.")
+        Long memberId
+) {
+    public AddFriendServiceRequest toService(){
+        return new AddFriendServiceRequest(memberId);
+    }
+}

--- a/src/main/java/team9/ddang/member/entity/Friend.java
+++ b/src/main/java/team9/ddang/member/entity/Friend.java
@@ -19,15 +19,15 @@ public class Friend extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id", nullable = false)
-    private Member senderId;
+    private Member sender;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id", nullable = false)
-    private Member receiverId;
+    private Member receiver;
 
     @Builder
-    private Friend(Member senderId, Member receiverId) {
-        this.senderId = senderId;
-        this.receiverId = receiverId;
+    private Friend(Member sender, Member receiver) {
+        this.sender = sender;
+        this.receiver = receiver;
     }
 }

--- a/src/main/java/team9/ddang/member/entity/FriendRequest.java
+++ b/src/main/java/team9/ddang/member/entity/FriendRequest.java
@@ -18,15 +18,15 @@ public class FriendRequest extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "sender_id", nullable = false)
-    private Member senderId;
+    private Member sender;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "receiver_id", nullable = false)
-    private Member receiverId;
+    private Member receiver;
 
     @Builder
-    private FriendRequest(Member senderId, Member receiverId) {
-        this.senderId = senderId;
-        this.receiverId = receiverId;
+    private FriendRequest(Member sender, Member receiver) {
+        this.sender = sender;
+        this.receiver = receiver;
     }
 }

--- a/src/main/java/team9/ddang/member/repository/FriendRepository.java
+++ b/src/main/java/team9/ddang/member/repository/FriendRepository.java
@@ -22,10 +22,10 @@ public interface FriendRepository  extends JpaRepository<Friend, Long> {
     @Modifying
     @Query("""
     DELETE FROM Friend f
-    WHERE f.sender = :sender 
-    AND f.receiver = :receiver
-    """)
-    void deleteBySenderAndReceiver(Member sender, Member receiver);
+    WHERE (f.sender = :member AND f.receiver = :otherMember)
+       OR (f.sender = :otherMember AND f.receiver = :member)
+""")
+    void deleteBySenderAndReceiver(Member member, Member otherMember);
 
     boolean existsBySenderAndReceiver(Member sender, Member receiver);
 }

--- a/src/main/java/team9/ddang/member/repository/FriendRepository.java
+++ b/src/main/java/team9/ddang/member/repository/FriendRepository.java
@@ -1,0 +1,31 @@
+package team9.ddang.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import team9.ddang.member.entity.Friend;
+import team9.ddang.member.entity.Member;
+
+import java.util.List;
+
+public interface FriendRepository  extends JpaRepository<Friend, Long> {
+
+    @Query("""
+    SELECT f.receiver
+    FROM Friend f
+    WHERE f.sender = :sender
+    and f.isDeleted = 'FALSE'
+    and f.receiver.isDeleted = 'FALSE'
+    """)
+    List<Member> findAllFriendsBySender(Member sender);
+
+    @Modifying
+    @Query("""
+    DELETE FROM Friend f
+    WHERE f.sender = :sender 
+    AND f.receiver = :receiver
+    """)
+    void deleteBySenderAndReceiver(Member sender, Member receiver);
+
+    boolean existsBySenderAndReceiver(Member sender, Member receiver);
+}

--- a/src/main/java/team9/ddang/member/repository/FriendRequestRepository.java
+++ b/src/main/java/team9/ddang/member/repository/FriendRequestRepository.java
@@ -1,0 +1,12 @@
+package team9.ddang.member.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import team9.ddang.member.entity.FriendRequest;
+import team9.ddang.member.entity.Member;
+
+public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+
+    boolean existsFriendRequestByReceiver(Member receiver);
+
+    void deleteByReceiver(Member receiver);
+}

--- a/src/main/java/team9/ddang/member/service/FriendService.java
+++ b/src/main/java/team9/ddang/member/service/FriendService.java
@@ -1,6 +1,5 @@
 package team9.ddang.member.service;
 
-import jakarta.validation.Valid;
 import team9.ddang.member.controller.request.AddFriendRequest;
 import team9.ddang.member.entity.Member;
 import team9.ddang.member.service.response.FriendListResponse;
@@ -10,7 +9,7 @@ import team9.ddang.member.service.response.MemberResponse;
 import java.util.List;
 
 public interface FriendService {
-    MemberResponse addFriend(Member member, @Valid AddFriendRequest addFriendRequest);
+    MemberResponse addFriend(Member member, AddFriendRequest addFriendRequest);
 
     List<FriendListResponse> getFriendList(Member member);
 

--- a/src/main/java/team9/ddang/member/service/FriendService.java
+++ b/src/main/java/team9/ddang/member/service/FriendService.java
@@ -1,0 +1,20 @@
+package team9.ddang.member.service;
+
+import jakarta.validation.Valid;
+import team9.ddang.member.controller.request.AddFriendRequest;
+import team9.ddang.member.entity.Member;
+import team9.ddang.member.service.response.FriendListResponse;
+import team9.ddang.member.service.response.FriendResponse;
+import team9.ddang.member.service.response.MemberResponse;
+
+import java.util.List;
+
+public interface FriendService {
+    MemberResponse addFriend(Member member, @Valid AddFriendRequest addFriendRequest);
+
+    List<FriendListResponse> getFriendList(Member member);
+
+    FriendResponse getFriend(Member member, Long memberId);
+
+    void deleteFriend(Member member, Long memberId);
+}

--- a/src/main/java/team9/ddang/member/service/FriendServiceImpl.java
+++ b/src/main/java/team9/ddang/member/service/FriendServiceImpl.java
@@ -84,22 +84,15 @@ public class FriendServiceImpl implements FriendService{
         }
 
         friendRepository.deleteBySenderAndReceiver(member, otherMember);
-        friendRepository.deleteBySenderAndReceiver(otherMember, member);
     }
 
     private void saveFriend(Member member, Member otherMember){
-        Friend friend = Friend.builder()
-                .sender(member)
-                .receiver(otherMember)
-                .build();
+        List<Friend> friends = List.of(
+                Friend.builder().sender(member).receiver(otherMember).build(),
+                Friend.builder().sender(otherMember).receiver(member).build()
+        );
 
-        Friend friend2 = Friend.builder()
-                .sender(otherMember)
-                .receiver(member)
-                .build();
-
-        friendRepository.save(friend);
-        friendRepository.save(friend2);
+        friendRepository.saveAll(friends);
         friendRequestRepository.deleteByReceiver(member);
     }
 

--- a/src/main/java/team9/ddang/member/service/FriendServiceImpl.java
+++ b/src/main/java/team9/ddang/member/service/FriendServiceImpl.java
@@ -1,0 +1,119 @@
+package team9.ddang.member.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import team9.ddang.dog.entity.Dog;
+import team9.ddang.dog.repository.MemberDogRepository;
+import team9.ddang.member.controller.request.AddFriendRequest;
+import team9.ddang.member.entity.Friend;
+import team9.ddang.member.entity.FriendRequest;
+import team9.ddang.member.entity.Member;
+import team9.ddang.member.repository.FriendRepository;
+import team9.ddang.member.repository.FriendRequestRepository;
+import team9.ddang.member.repository.MemberRepository;
+import team9.ddang.member.repository.WalkWithMemberRepository;
+import team9.ddang.member.service.response.FriendListResponse;
+import team9.ddang.member.service.response.FriendResponse;
+import team9.ddang.member.service.response.MemberResponse;
+import team9.ddang.walk.repository.WalkRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class FriendServiceImpl implements FriendService{
+
+    private final MemberRepository memberRepository;
+    private final FriendRequestRepository friendRequestRepository;
+    private final FriendRepository friendRepository;
+    private final MemberDogRepository memberDogRepository;
+    private final WalkRepository walkRepository;
+    private final WalkWithMemberRepository walkWithMemberRepository;
+
+    @Override
+    @Transactional
+    public MemberResponse addFriend(Member member, AddFriendRequest addFriendRequest) {
+        Member otherMember = getMemberFromMemberIdOrElseThrow(addFriendRequest.memberId());
+
+        if(friendRequestRepository.existsFriendRequestByReceiver(member)){
+            saveFriend(member, otherMember);
+        }
+        else {
+            createFriendRequest(member, otherMember);
+        }
+
+        return MemberResponse.from(otherMember);
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<FriendListResponse> getFriendList(Member member) {
+        List<Member> friends = friendRepository.findAllFriendsBySender(member);
+
+        return friends.stream().map(FriendListResponse::from).toList();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public FriendResponse getFriend(Member member, Long memberId) {
+        Member otherMember = getMemberFromMemberIdOrElseThrow(memberId);
+
+        if(!friendRepository.existsBySenderAndReceiver(member, otherMember)){
+            throw new IllegalArgumentException("친구가 아닌 사람의 프로필은 볼 수 없습니다.");
+        }
+
+        Dog dog = memberDogRepository.findMemberDogByMemberId(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("강아지가 존재하지 않습니다.")).getDog();
+
+        int totalDistanceInMeters = walkRepository.findTotalDistanceByMemberId(memberId);
+        int countWalks = walkRepository.countWalksByMemberId(memberId);
+        double totalDistanceInKilometers = totalDistanceInMeters / 1000.0;
+        int countWalksWithMember = walkWithMemberRepository.countBySenderMemberId(memberId);
+
+        return FriendResponse.of(otherMember, dog, totalDistanceInKilometers, countWalks ,countWalksWithMember);
+    }
+
+    @Override
+    @Transactional
+    public void deleteFriend(Member member, Long memberId) {
+        Member otherMember = getMemberFromMemberIdOrElseThrow(memberId);
+
+        if(!friendRepository.existsBySenderAndReceiver(member, otherMember)){
+            throw new IllegalArgumentException("친구가 아닌 사람을 삭제할 수 없습니다.");
+        }
+
+        friendRepository.deleteBySenderAndReceiver(member, otherMember);
+        friendRepository.deleteBySenderAndReceiver(otherMember, member);
+    }
+
+    private void saveFriend(Member member, Member otherMember){
+        Friend friend = Friend.builder()
+                .sender(member)
+                .receiver(otherMember)
+                .build();
+
+        Friend friend2 = Friend.builder()
+                .sender(otherMember)
+                .receiver(member)
+                .build();
+
+        friendRepository.save(friend);
+        friendRepository.save(friend2);
+        friendRequestRepository.deleteByReceiver(member);
+    }
+
+    private void createFriendRequest(Member member, Member otherMember){
+        // 친구 요청 추가
+        FriendRequest friendRequest = FriendRequest.builder()
+                .sender(member)
+                .receiver(otherMember)
+                .build();
+
+        friendRequestRepository.save(friendRequest);
+    }
+
+    private Member getMemberFromMemberIdOrElseThrow(Long memberId){
+        return memberRepository.findById(memberId).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 멤버 입니다."));
+    }
+}

--- a/src/main/java/team9/ddang/member/service/request/AddFriendServiceRequest.java
+++ b/src/main/java/team9/ddang/member/service/request/AddFriendServiceRequest.java
@@ -1,0 +1,6 @@
+package team9.ddang.member.service.request;
+
+public record AddFriendServiceRequest(
+        Long memberId
+) {
+}

--- a/src/main/java/team9/ddang/member/service/response/FriendListResponse.java
+++ b/src/main/java/team9/ddang/member/service/response/FriendListResponse.java
@@ -11,7 +11,7 @@ public record FriendListResponse(
         Long memberId,
 
         @Schema(description = "회원 성별", example = "MALE")
-        Gender memberGender,
+        Gender gender,
 
         @Schema(description = "가족 내 역할", example = "FATHER")
         FamilyRole familyRole

--- a/src/main/java/team9/ddang/member/service/response/FriendListResponse.java
+++ b/src/main/java/team9/ddang/member/service/response/FriendListResponse.java
@@ -1,0 +1,22 @@
+package team9.ddang.member.service.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team9.ddang.global.entity.Gender;
+import team9.ddang.member.entity.FamilyRole;
+import team9.ddang.member.entity.Member;
+
+public record FriendListResponse(
+
+        @Schema(description = "회원 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "회원 성별", example = "MALE")
+        Gender memberGender,
+
+        @Schema(description = "가족 내 역할", example = "FATHER")
+        FamilyRole familyRole
+) {
+    public static FriendListResponse from(Member member){
+        return new FriendListResponse(member.getMemberId(), member.getGender(), member.getFamilyRole());
+    }
+}

--- a/src/main/java/team9/ddang/member/service/response/FriendResponse.java
+++ b/src/main/java/team9/ddang/member/service/response/FriendResponse.java
@@ -1,0 +1,85 @@
+package team9.ddang.member.service.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import team9.ddang.dog.entity.Dog;
+import team9.ddang.dog.entity.IsNeutered;
+import team9.ddang.global.entity.Gender;
+import team9.ddang.member.entity.FamilyRole;
+import team9.ddang.member.entity.Member;
+import team9.ddang.walk.util.DateCalculator;
+
+public record FriendResponse(
+        @Schema(description = "회원 ID", example = "1")
+        Long memberId,
+
+        @Schema(description = "회원 이름", example = "John Doe")
+        String memberName,
+
+        @Schema(description = "회원 주소", example = "123 Main Street")
+        String address,
+
+        @Schema(description = "회원 성별", example = "MALE")
+        Gender memberGender,
+
+        @Schema(description = "가족 내 역할", example = "FATHER")
+        FamilyRole familyRole,
+
+        @Schema(description = "회원 프로필 이미지 URL", example = "https://example.com/profile.jpg")
+        String memberProfileImg,
+
+        @Schema(description = "총 산책 거리 (킬로미터)", example = "12.5")
+        double totalDistance,
+
+        @Schema(description = "총 산책 횟수", example = "5")
+        int walkCount,
+
+        @Schema(description = "강번따 횟수", example = "3")
+        int countWalksWithMember,
+
+        @Schema(description = "강아지 ID", example = "101")
+        Long dogId,
+
+        @Schema(description = "강아지 이름", example = "Rex")
+        String dogName,
+
+        @Schema(description = "강아지 품종", example = "Golden Retriever")
+        String dogBreed,
+
+        @Schema(description = "강아지 나이", example = "5")
+        long dogAge,
+
+        @Schema(description = "강아지 무게 (킬로그램)", example = "30")
+        Integer dogWeight,
+
+        @Schema(description = "강아지 성별", example = "MALE")
+        Gender dogGender,
+
+        @Schema(description = "강아지 프로필 이미지 URL", example = "https://example.com/dog_profile.jpg")
+        String dogProfileImg,
+
+        @Schema(description = "중성화 여부", example = "YES")
+        IsNeutered isNeutered
+
+) {
+    public static FriendResponse of(Member member,  Dog dog, double totalDistance, int walkCount, int countWalksWithMember) {
+        return new FriendResponse(
+                member.getMemberId(),
+                member.getName(),
+                member.getAddress(),
+                member.getGender(),
+                member.getFamilyRole(),
+                member.getProfileImg(),
+                totalDistance,
+                walkCount,
+                countWalksWithMember,
+                dog.getDogId(),
+                dog.getName(),
+                dog.getBreed(),
+                DateCalculator.calculateAgeFromNow(dog.getBirthDate()),
+                dog.getWeight(),
+                dog.getGender(),
+                dog.getProfileImg(),
+                dog.getIsNeutered()
+        );
+    }
+}

--- a/src/test/java/team9/ddang/ApiTestSupport.java
+++ b/src/test/java/team9/ddang/ApiTestSupport.java
@@ -8,15 +8,18 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 import team9.ddang.family.controller.FamilyController;
 import team9.ddang.family.service.FamilyService;
+import team9.ddang.member.controller.FriendController;
 import team9.ddang.member.controller.MemberController;
 import team9.ddang.member.jwt.filter.JwtAuthenticationProcessingFilter;
 import team9.ddang.member.jwt.service.JwtService;
 import team9.ddang.member.service.CookieService;
+import team9.ddang.member.service.FriendService;
 import team9.ddang.member.service.MemberService;
 
 @WebMvcTest(controllers = {
         MemberController.class,
-        FamilyController.class
+        FamilyController.class,
+        FriendController.class
 })
 @AutoConfigureMockMvc(addFilters = false)
 public abstract class ApiTestSupport {
@@ -41,6 +44,9 @@ public abstract class ApiTestSupport {
 
     @MockBean
     protected FamilyService familyService;
+
+    @MockBean
+    protected FriendService friendService;
 
     // MockBean 통해서 실제 빈을 대체하는 가짜 빈을 주입
     // 사용하는 서비스들은 모두 MockBean으로 주입

--- a/src/test/java/team9/ddang/member/controller/FriendControllerTest.java
+++ b/src/test/java/team9/ddang/member/controller/FriendControllerTest.java
@@ -1,0 +1,294 @@
+package team9.ddang.member.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithMockUser;
+import team9.ddang.ApiTestSupport;
+import team9.ddang.dog.entity.Dog;
+import team9.ddang.dog.entity.IsNeutered;
+import team9.ddang.global.entity.Gender;
+import team9.ddang.member.controller.request.AddFriendRequest;
+import team9.ddang.member.entity.*;
+import team9.ddang.member.oauth2.CustomOAuth2User;
+import team9.ddang.member.service.response.FriendListResponse;
+import team9.ddang.member.service.response.FriendResponse;
+import team9.ddang.member.service.response.MemberResponse;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@MockBean(JpaMetamodelMappingContext.class)
+class FriendControllerTest extends ApiTestSupport {
+
+    @Test
+    @DisplayName("친구를 추가한다.")
+    @WithMockUser
+    void addFriend() throws Exception {
+        //given
+        Long memberId = 1L;
+        AddFriendRequest request = new AddFriendRequest(memberId);
+
+        Member member = Member.builder()
+                .memberId(1L)
+                .birthDate(LocalDate.of(1999,9,3))
+                .name("mjk")
+                .email("user@example.com")
+                .role(Role.USER)
+                .address("Incheon")
+                .isMatched(IsMatched.TRUE)
+                .gender(Gender.MALE)
+                .provider(Provider.GOOGLE)
+                .profileImg("profileImg1.png")
+                .familyRole(FamilyRole.BROTHER)
+                .build();
+
+        // Mock된 사용자 설정
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(
+                Collections.emptySet(),
+                Map.of("email", "user@example.com"),
+                "email",
+              member
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities())
+        );
+        MemberResponse response = MemberResponse.from(member);
+        String accessToken = jwtService.createAccessToken(member.getEmail(), "GOOGLE");
+
+        //when
+        given(friendService.addFriend(any(Member.class), eq(request)))
+                .willReturn(response);
+
+
+        //then
+        mockMvc.perform(post("/api/v1/friend")
+                .content(objectMapper.writeValueAsString(request))
+                .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.memberId").value(1L))
+                .andExpect(jsonPath("$.data.email").value("user@example.com"))
+                .andExpect(jsonPath("$.data.name").value("mjk"))
+                .andExpect(jsonPath("$.data.provider").value("GOOGLE"))
+                .andExpect(jsonPath("$.data.birthDate").value("1999-09-03"))
+                .andExpect(jsonPath("$.data.gender").value("MALE"))
+                .andExpect(jsonPath("$.data.address").value("Incheon"))
+                .andExpect(jsonPath("$.data.familyRole").value("BROTHER"))
+                .andExpect(jsonPath("$.data.profileImg").value("profileImg1.png"));
+    }
+
+    @Test
+    @DisplayName("친구 리스트를 조회한다.")
+    @WithMockUser
+    void getFriendList() throws Exception {
+        //given
+        Long memberId = 1L;
+
+        Member member = Member.builder()
+                .memberId(2L)
+                .birthDate(LocalDate.of(1999,9,3))
+                .name("mjk")
+                .email("user@example.com")
+                .role(Role.USER)
+                .address("Incheon")
+                .isMatched(IsMatched.TRUE)
+                .gender(Gender.MALE)
+                .provider(Provider.GOOGLE)
+                .profileImg("profileImg1.png")
+                .familyRole(FamilyRole.BROTHER)
+                .build();
+
+        List<FriendListResponse> response = new ArrayList<>();
+        FriendListResponse friendListResponse = FriendListResponse.from(member);
+        response.add(friendListResponse);
+
+        String accessToken = jwtService.createAccessToken("user@example.com", "GOOGLE");
+
+        // Mock된 사용자 설정
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(
+                Collections.emptySet(),
+                Map.of("email", "user@example.com"),
+                "email",
+                Member.builder()
+                        .memberId(memberId)
+                        .name("hhj")
+                        .email("user2@example.com")
+                        .isMatched(IsMatched.TRUE)
+                        .build()
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities())
+        );
+
+        //when
+        given(friendService.getFriendList(any(Member.class)))
+                .willReturn(response);
+
+        //then
+        mockMvc.perform(get("/api/v1/friend")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data[0].memberId").value(2L))
+                .andExpect(jsonPath("$.data[0].gender").value("MALE"))
+                .andExpect(jsonPath("$.data[0].familyRole").value("BROTHER"));
+
+    }
+
+    @Test
+    @DisplayName("친구의 프로필을 상세 조회한다.")
+    @WithMockUser
+    void getFriend() throws Exception {
+        //given
+        Long memberId = 1L;
+
+        String accessToken = jwtService.createAccessToken("user@example.com", "GOOGLE");
+
+        Member member = Member.builder()
+                .memberId(2L)
+                .birthDate(LocalDate.of(1999,9,3))
+                .name("mjk")
+                .email("user@example.com")
+                .role(Role.USER)
+                .address("Incheon")
+                .isMatched(IsMatched.TRUE)
+                .gender(Gender.MALE)
+                .provider(Provider.GOOGLE)
+                .profileImg("profileImg1.png")
+                .familyRole(FamilyRole.BROTHER)
+                .build();
+
+        // Mock된 사용자 설정
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(
+                Collections.emptySet(),
+                Map.of("email", "user@example.com"),
+                "email",
+                Member.builder()
+                        .memberId(memberId)
+                        .name("hhh")
+                        .email("user2@example.com")
+                        .isMatched(IsMatched.TRUE)
+                        .build()
+        );
+
+        Dog dog = Dog.builder()
+                .breed("말티즈")
+                .birthDate(LocalDate.of(2023,1,1))
+                .name("쪼꼬")
+                .weight(3)
+                .isNeutered(IsNeutered.TRUE)
+                .profileImg("profile")
+                .gender(Gender.MALE)
+                        .build();
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities())
+        );
+
+        FriendResponse response = FriendResponse.of(member, dog, 30, 10, 10);
+
+        //when
+        given(friendService.getFriend(any(Member.class), eq(2L)))
+                .willReturn(response);
+
+        //then
+        mockMvc.perform(get("/api/v1/friend/{memberId}", 2L) // PathVariable로 memberId 추가
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("200"))
+                .andExpect(jsonPath("$.status").value("OK"))
+                .andExpect(jsonPath("$.message").value("OK"))
+                .andExpect(jsonPath("$.data.memberId").value(2L))
+                .andExpect(jsonPath("$.data.memberName").value("mjk"))
+                .andExpect(jsonPath("$.data.address").value("Incheon"))
+                .andExpect(jsonPath("$.data.memberGender").value("MALE"))
+                .andExpect(jsonPath("$.data.familyRole").value("BROTHER"))
+                .andExpect(jsonPath("$.data.memberProfileImg").value("profileImg1.png"))
+                .andExpect(jsonPath("$.data.totalDistance").value("30.0"))
+                .andExpect(jsonPath("$.data.walkCount").value("10"))
+                .andExpect(jsonPath("$.data.countWalksWithMember").value("10"))
+                .andExpect(jsonPath("$.data.dogId").isEmpty())
+                .andExpect(jsonPath("$.data.dogName").value("쪼꼬"))
+                .andExpect(jsonPath("$.data.dogBreed").value("말티즈"))
+                .andExpect(jsonPath("$.data.dogAge").value("2"))
+                .andExpect(jsonPath("$.data.dogWeight").value("3"))
+                .andExpect(jsonPath("$.data.dogGender").value("MALE"))
+                .andExpect(jsonPath("$.data.dogProfileImg").value("profile"))
+                .andExpect(jsonPath("$.data.isNeutered").value("TRUE"));
+
+    }
+
+    @Test
+    @DisplayName("친구를 삭제한다")
+    @WithMockUser
+    void deleteFriend() throws Exception {
+        //given
+        Long memberId = 1L;
+
+        String accessToken = jwtService.createAccessToken("user@example.com", "GOOGLE");
+
+        // Mock된 사용자 설정
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(
+                Collections.emptySet(),
+                Map.of("email", "user@example.com"),
+                "email",
+                Member.builder()
+                        .memberId(memberId)
+                        .name("mjk")
+                        .email("user@example.com")
+                        .isMatched(IsMatched.TRUE)
+                        .build()
+        );
+
+        SecurityContextHolder.getContext().setAuthentication(
+                new UsernamePasswordAuthenticationToken(customOAuth2User, null, customOAuth2User.getAuthorities())
+        );
+
+
+        //when
+        doNothing().when(friendService).deleteFriend(any(Member.class), eq(2L));
+
+
+        //then
+        mockMvc.perform(delete("/api/v1/friend/{memberId}", 2L) // PathVariable로 memberId 추가
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value("204"))
+                .andExpect(jsonPath("$.status").value("NO_CONTENT"))
+                .andExpect(jsonPath("$.message").value("No Content"))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- 친구 요청, 추가 API 추가
- 친구 상세 조회 추가
- 친구 목록 조회 추가
- 친구 삭제 기능 추가

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #24 
<br>

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
가장 크게 고민이 많았던 부분이 delete 건에 관해서였는데요, FriendRequest 야 요청에 들어가 있는 것이 Pending 상태이고 받으면 삭제하는게 맞다고 저번에도 얘기나눴어서 일단 삭제 처리를 했습니다.

Friend 부분을 soft Delete 를 할까 고민을 했는데, SQL에 데이터가 많을 수록 조회 성능이 떨어진다고도 하고 저희가 저장을 둘 다 하니까 저장되는 양도 많을 테고 그래서 아직 삭제를 했을 때 남겨놔야 하는 이유도 아직 잘 모르겠어서 일단 성능 쪽을 좀 더 챙긴다는 생각으로 soft delete 를 적용하진 않았습니다. 

추후에 개발 진행되면서 친구 였던 기록이 필요하겠다 싶으면 쿼리문을 좀 바꿀 필요가 있을 것 같습니다.

테스트는 일단 간단하게 API 컨트롤러 테스트만 구현하였습니다.