### PR TITLE
[Feat/#23] feat chatroom auth

### DIFF
--- a/src/main/java/team9/ddang/chat/consumer/ChatConsumer.java
+++ b/src/main/java/team9/ddang/chat/consumer/ChatConsumer.java
@@ -8,7 +8,9 @@ import team9.ddang.chat.controller.request.ChatRequest;
 import team9.ddang.chat.event.MessageReadEvent;
 import team9.ddang.chat.service.ChatService;
 import team9.ddang.chat.service.WebSocketMessageService;
+import team9.ddang.chat.service.request.ChatReadServiceRequest;
 import team9.ddang.chat.service.request.ChatServiceRequest;
+import team9.ddang.chat.service.response.ChatReadResponse;
 import team9.ddang.chat.service.response.ChatResponse;
 
 
@@ -38,10 +40,12 @@ public class ChatConsumer {
 
     public void consumeReadEvent(String topic, String message) {
         try {
-            MessageReadEvent readEvent = objectMapper.readValue(message, MessageReadEvent.class);
+            ChatReadServiceRequest chatReadServiceRequest = objectMapper.readValue(message, ChatReadServiceRequest.class);
 
-            String destination = "/sub/chat/" + readEvent.chatRoomId();
-            webSocketMessageService.broadcastMessage(destination, readEvent);
+            ChatReadResponse chatReadResponse = chatService.updateMessageReadStatus(chatReadServiceRequest.chatRoomId(),chatReadServiceRequest.email());
+
+            String destination = "/sub/chat/" + chatReadServiceRequest.chatRoomId();
+            webSocketMessageService.broadcastMessage(destination, chatReadResponse);
 
             log.info("Read event broadcasted to WebSocket: {}", destination);
         } catch (Exception e) {

--- a/src/main/java/team9/ddang/chat/consumer/ChatConsumer.java
+++ b/src/main/java/team9/ddang/chat/consumer/ChatConsumer.java
@@ -24,7 +24,7 @@ public class ChatConsumer {
         try {
             ChatRequest chatRequest = objectMapper.readValue(message, ChatRequest.class);
 
-            ChatResponse chatResponse = chatService.saveChat(chatRequest.chatRoomId(), chatRequest.memberId(), chatRequest.message());
+            ChatResponse chatResponse = chatService.saveChat(chatRequest.chatRoomId(), 2L, chatRequest.message());
 
             String destination = "/sub/chat/" + chatRequest.chatRoomId();
             webSocketMessageService.broadcastMessage(destination, chatResponse);

--- a/src/main/java/team9/ddang/chat/consumer/ChatConsumer.java
+++ b/src/main/java/team9/ddang/chat/consumer/ChatConsumer.java
@@ -4,14 +4,13 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import team9.ddang.chat.controller.request.ChatRequest;
-import team9.ddang.chat.event.MessageReadEvent;
 import team9.ddang.chat.service.ChatService;
 import team9.ddang.chat.service.WebSocketMessageService;
 import team9.ddang.chat.service.request.ChatReadServiceRequest;
 import team9.ddang.chat.service.request.ChatServiceRequest;
 import team9.ddang.chat.service.response.ChatReadResponse;
 import team9.ddang.chat.service.response.ChatResponse;
+import team9.ddang.global.api.WebSocketResponse;
 
 
 @Slf4j
@@ -30,7 +29,7 @@ public class ChatConsumer {
             ChatResponse chatResponse = chatService.saveChat(chatServiceRequest.chatRoomId(), chatServiceRequest.email(), chatServiceRequest.message());
 
             String destination = "/sub/chat/" + chatServiceRequest.chatRoomId();
-            webSocketMessageService.broadcastMessage(destination, chatResponse);
+            webSocketMessageService.broadcastMessage(destination, WebSocketResponse.ok(chatResponse));
 
             log.info("Message broadcasted to WebSocket: {}", destination);
         } catch (Exception e) {
@@ -42,10 +41,10 @@ public class ChatConsumer {
         try {
             ChatReadServiceRequest chatReadServiceRequest = objectMapper.readValue(message, ChatReadServiceRequest.class);
 
-            ChatReadResponse chatReadResponse = chatService.updateMessageReadStatus(chatReadServiceRequest.chatRoomId(),chatReadServiceRequest.email());
+            ChatReadResponse chatReadResponse = chatService.updateMessageReadStatus(chatReadServiceRequest.chatRoomId(), chatReadServiceRequest.email());
 
             String destination = "/sub/chat/" + chatReadServiceRequest.chatRoomId();
-            webSocketMessageService.broadcastMessage(destination, chatReadResponse);
+            webSocketMessageService.broadcastMessage(destination, WebSocketResponse.ok(chatReadResponse));
 
             log.info("Read event broadcasted to WebSocket: {}", destination);
         } catch (Exception e) {

--- a/src/main/java/team9/ddang/chat/consumer/ChatConsumer.java
+++ b/src/main/java/team9/ddang/chat/consumer/ChatConsumer.java
@@ -8,6 +8,7 @@ import team9.ddang.chat.controller.request.ChatRequest;
 import team9.ddang.chat.event.MessageReadEvent;
 import team9.ddang.chat.service.ChatService;
 import team9.ddang.chat.service.WebSocketMessageService;
+import team9.ddang.chat.service.request.ChatServiceRequest;
 import team9.ddang.chat.service.response.ChatResponse;
 
 
@@ -22,11 +23,11 @@ public class ChatConsumer {
 
     public void consumeMessage(String topic, String message) {
         try {
-            ChatRequest chatRequest = objectMapper.readValue(message, ChatRequest.class);
+            ChatServiceRequest chatServiceRequest = objectMapper.readValue(message, ChatServiceRequest.class);
 
-            ChatResponse chatResponse = chatService.saveChat(chatRequest.chatRoomId(), 2L, chatRequest.message());
+            ChatResponse chatResponse = chatService.saveChat(chatServiceRequest.chatRoomId(), chatServiceRequest.email(), chatServiceRequest.message());
 
-            String destination = "/sub/chat/" + chatRequest.chatRoomId();
+            String destination = "/sub/chat/" + chatServiceRequest.chatRoomId();
             webSocketMessageService.broadcastMessage(destination, chatResponse);
 
             log.info("Message broadcasted to WebSocket: {}", destination);

--- a/src/main/java/team9/ddang/chat/controller/ChatController.java
+++ b/src/main/java/team9/ddang/chat/controller/ChatController.java
@@ -2,8 +2,6 @@ package team9.ddang.chat.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +19,6 @@ import team9.ddang.chat.service.ChatService;
 import team9.ddang.chat.service.request.ChatReadServiceRequest;
 import team9.ddang.chat.service.request.ChatServiceRequest;
 import team9.ddang.chat.service.response.ChatResponse;
-import team9.ddang.chat.service.response.SliceResponse;
 import team9.ddang.global.aop.AuthenticationContext;
 import team9.ddang.global.aop.ExtractEmail;
 import team9.ddang.global.api.ApiResponse;
@@ -53,42 +50,16 @@ public class ChatController {
 
         ChatReadServiceRequest chatReadServiceRequest = chatReadRequest.toServiceRequest(AuthenticationContext.getEmail());
 
-        chatProducer.sendReadEvent("topic-chat-"+ chatReadRequest.chatRoomId(), chatReadServiceRequest);
+        chatProducer.sendReadEvent("topic-chat-" + chatReadRequest.chatRoomId(), chatReadServiceRequest);
     }
 
     @GetMapping("/{chatRoomId}")
     @Operation(
             summary = "채팅방 메시지 조회",
-            description = "특정 채팅방의 메시지를 페이징 형태로 조회합니다.",
+            description = "특정 채팅방의 메시지를 페이징 형태로 조회합니다. 또한, 채팅방 입장으로 간주하여, /sub/chat/{chatRoomId} 구독 경로로 메세지 읽음 여부를 broadcast 합니다.",
             parameters = {
                     @Parameter(name = "chatRoomId", description = "조회할 채팅방 ID", required = true, example = "1"),
                     @Parameter(name = "page", description = "페이지 번호 (기본값: 0)", example = "0")
-            },
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "채팅방 메시지 조회 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = SliceResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "400",
-                            description = "잘못된 요청 데이터",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    )
             }
     )
     public ApiResponse<Slice<ChatResponse>> getChatMessages(

--- a/src/main/java/team9/ddang/chat/controller/ChatController.java
+++ b/src/main/java/team9/ddang/chat/controller/ChatController.java
@@ -18,6 +18,7 @@ import team9.ddang.chat.controller.request.ChatReadRequest;
 import team9.ddang.chat.controller.request.ChatRequest;
 import team9.ddang.chat.producer.ChatProducer;
 import team9.ddang.chat.service.ChatService;
+import team9.ddang.chat.service.request.ChatReadServiceRequest;
 import team9.ddang.chat.service.request.ChatServiceRequest;
 import team9.ddang.chat.service.response.ChatResponse;
 import team9.ddang.chat.service.response.SliceResponse;
@@ -46,10 +47,13 @@ public class ChatController {
         chatProducer.sendMessage("topic-chat-" + chatRequest.chatRoomId(), chatServiceRequest);
     }
 
-    @MessageMapping("/api/v1/chat/ack/{chatRoomId}")
-    public void handleMessageAck(@Valid ChatReadRequest chatReadRequest) {
+    @MessageMapping("/api/v1/chat/ack")
+    @ExtractEmail
+    public void handleMessageAck(SimpMessageHeaderAccessor headerAccessor, @Valid ChatReadRequest chatReadRequest) {
 
-        chatService.updateMessageReadStatus(chatReadRequest.chatRoomId());
+        ChatReadServiceRequest chatReadServiceRequest = chatReadRequest.toServiceRequest(AuthenticationContext.getEmail());
+
+        chatProducer.sendReadEvent("topic-chat-"+ chatReadRequest.chatRoomId(), chatReadServiceRequest);
     }
 
     @GetMapping("/{chatRoomId}")

--- a/src/main/java/team9/ddang/chat/controller/ChatRoomController.java
+++ b/src/main/java/team9/ddang/chat/controller/ChatRoomController.java
@@ -5,11 +5,13 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import team9.ddang.chat.controller.request.ChatRoomCreateRequest;
 import team9.ddang.chat.service.ChatRoomService;
 import team9.ddang.chat.service.response.ChatRoomResponse;
 import team9.ddang.global.api.ApiResponse;
+import team9.ddang.member.oauth2.CustomOAuth2User;
 
 import java.util.List;
 
@@ -72,9 +74,10 @@ public class ChatRoomController {
             }
     )
     public ApiResponse<ChatRoomResponse> createChatRoom(
-            @RequestBody ChatRoomCreateRequest request
+            @RequestBody ChatRoomCreateRequest request,
+            @AuthenticationPrincipal CustomOAuth2User currentUser
     ) {
-        ChatRoomResponse response = chatRoomService.createChatRoom(request.toServiceRequest());
+        ChatRoomResponse response = chatRoomService.createChatRoom(request.toServiceRequest(), currentUser.getMember());
         return ApiResponse.ok(response);
     }
 
@@ -113,8 +116,8 @@ public class ChatRoomController {
                     )
             }
     )
-    public ApiResponse<List<ChatRoomResponse>> getChatRooms() {
-        List<ChatRoomResponse> chatRooms = chatRoomService.getChatRoomsForAuthenticatedMember();
+    public ApiResponse<List<ChatRoomResponse>> getChatRooms(@AuthenticationPrincipal CustomOAuth2User currentUser) {
+        List<ChatRoomResponse> chatRooms = chatRoomService.getChatRoomsForAuthenticatedMember(currentUser.getMember());
         return ApiResponse.ok(chatRooms);
     }
 }

--- a/src/main/java/team9/ddang/chat/controller/ChatRoomController.java
+++ b/src/main/java/team9/ddang/chat/controller/ChatRoomController.java
@@ -37,41 +37,7 @@ public class ChatRoomController {
                             mediaType = "application/json",
                             schema = @Schema(implementation = ChatRoomCreateRequest.class)
                     )
-            ),
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "채팅방 생성 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ChatRoomResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "이미 해당 유저와의 채팅방이 있는 경우",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ChatRoomResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "400",
-                            description = "잘못된 요청 데이터",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    )
-            }
+            )
     )
     public ApiResponse<ChatRoomResponse> createChatRoom(
             @RequestBody ChatRoomCreateRequest request,
@@ -86,35 +52,8 @@ public class ChatRoomController {
             summary = "사용자의 채팅방 목록 조회",
             description = """
                     현재 인증된 사용자가 참여 중인 채팅방 목록을 조회합니다.
-                    각 채팅방 정보에 추가적으로 마지막 메시지 정보가 포함됩니다.
-                    시큐리티 완성 시, 채팅방에 참여중인 member 정보가 추가될 예정입니다.
-                    """,
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "채팅방 목록 조회 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ChatRoomResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "401",
-                            description = "인증 실패",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    )
-            }
+                    각 채팅방 정보에 추가적으로 마지막 메시지 정보, 읽지 않은 채팅 개수, 채팅방에 참여중인 member 정보가 포함됩니다.
+                    """
     )
     public ApiResponse<List<ChatRoomResponse>> getChatRooms(@AuthenticationPrincipal CustomOAuth2User currentUser) {
         List<ChatRoomResponse> chatRooms = chatRoomService.getChatRoomsForAuthenticatedMember(currentUser.getMember());

--- a/src/main/java/team9/ddang/chat/controller/request/ChatReadRequest.java
+++ b/src/main/java/team9/ddang/chat/controller/request/ChatReadRequest.java
@@ -2,6 +2,7 @@ package team9.ddang.chat.controller.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import team9.ddang.chat.service.request.ChatReadServiceRequest;
 
 import java.util.List;
 
@@ -15,4 +16,7 @@ public record ChatReadRequest(
         @Schema(description = "읽음 처리된 메시지 ID 목록, 확장성을 고려하여 만든 것으로, 최종 제출까지는 null", example = "null")
         List<Long> readMessageIds
 ) {
+        public ChatReadServiceRequest toServiceRequest(String email) {
+                return new ChatReadServiceRequest(chatRoomId, email, readMessageIds);
+        }
 }

--- a/src/main/java/team9/ddang/chat/controller/request/ChatRequest.java
+++ b/src/main/java/team9/ddang/chat/controller/request/ChatRequest.java
@@ -7,10 +7,6 @@ import team9.ddang.chat.service.request.ChatServiceRequest;
 
 @Schema(description = "채팅 메시지 요청 데이터")
 public record ChatRequest(
-        // TODO 나중에는 SpringSequrity에서 맴버 객체 받아서 사용할 예정
-        @Schema(description = "메시지를 보낸 회원의 ID, SpringSequrity 완성시 삭제 예정 ", example = "123")
-        @NotNull(message = "회원 아이디는 필수입니다.")
-        Long memberId,
 
         @Schema(description = "채팅방 ID", example = "3")
         @NotNull(message = "채팅방 아이디는 필수입니다.")
@@ -21,6 +17,6 @@ public record ChatRequest(
         String message
 ) {
     public ChatServiceRequest toServiceRequest() {
-        return new ChatServiceRequest(memberId, chatRoomId, message);
+        return new ChatServiceRequest(chatRoomId, message);
     }
 }

--- a/src/main/java/team9/ddang/chat/controller/request/ChatRequest.java
+++ b/src/main/java/team9/ddang/chat/controller/request/ChatRequest.java
@@ -16,7 +16,7 @@ public record ChatRequest(
         @NotBlank(message = "채팅 메세지는 필수입니다.")
         String message
 ) {
-    public ChatServiceRequest toServiceRequest() {
-        return new ChatServiceRequest(chatRoomId, message);
+    public ChatServiceRequest toServiceRequest(String email) {
+        return new ChatServiceRequest(chatRoomId, email, message);
     }
 }

--- a/src/main/java/team9/ddang/chat/exception/ChatExceptionMessage.java
+++ b/src/main/java/team9/ddang/chat/exception/ChatExceptionMessage.java
@@ -13,6 +13,9 @@ public enum ChatExceptionMessage {
     // ChatRoom
     CHATROOM_NOT_FOUND("해당 채팅방을 찾을 수 없습니다."),
 
+    // MEMBER
+    MEMBER_NOT_FOUND("해당 맴버를 찾을 수 없습니다."),
+
     // ChatMember
     CHATMEMBER_NOT_IN_CHATROOM("해당 회원을 채팅방에서 찾을 수 없습니다.");
 

--- a/src/main/java/team9/ddang/chat/producer/ChatProducer.java
+++ b/src/main/java/team9/ddang/chat/producer/ChatProducer.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import team9.ddang.chat.controller.request.ChatRequest;
 import team9.ddang.chat.event.MessageReadEvent;
 import team9.ddang.chat.exception.ChatExceptionMessage;
+import team9.ddang.chat.service.request.ChatServiceRequest;
 
 @Service
 @RequiredArgsConstructor
@@ -15,9 +16,9 @@ public class ChatProducer {
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ObjectMapper objectMapper;
 
-    public void sendMessage(String topic, ChatRequest chatRequest) {
+    public void sendMessage(String topic, ChatServiceRequest chatServiceRequest) {
         try {
-            String message = objectMapper.writeValueAsString(chatRequest);
+            String message = objectMapper.writeValueAsString(chatServiceRequest);
             kafkaTemplate.send(topic, message);
         } catch (Exception e) {
             throw new IllegalArgumentException(ChatExceptionMessage.CHAT_JSON_PROCESSING_ERROR.getText(), e);

--- a/src/main/java/team9/ddang/chat/producer/ChatProducer.java
+++ b/src/main/java/team9/ddang/chat/producer/ChatProducer.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import team9.ddang.chat.controller.request.ChatRequest;
 import team9.ddang.chat.event.MessageReadEvent;
 import team9.ddang.chat.exception.ChatExceptionMessage;
+import team9.ddang.chat.service.request.ChatReadServiceRequest;
 import team9.ddang.chat.service.request.ChatServiceRequest;
 
 @Service
@@ -25,9 +26,9 @@ public class ChatProducer {
         }
     }
 
-    public void sendReadEvent(String topic, MessageReadEvent readEvent) {
+    public void sendReadEvent(String topic, ChatReadServiceRequest chatReadServiceRequest) {
         try {
-            String message = objectMapper.writeValueAsString(readEvent);
+            String message = objectMapper.writeValueAsString(chatReadServiceRequest);
             kafkaTemplate.send(topic, message);
         } catch (Exception e) {
             throw new IllegalArgumentException("Failed to send MessageReadEvent", e);

--- a/src/main/java/team9/ddang/chat/repository/ChatMemberRepository.java
+++ b/src/main/java/team9/ddang/chat/repository/ChatMemberRepository.java
@@ -21,4 +21,8 @@ public interface ChatMemberRepository extends JpaRepository<ChatMember, Long> {
     @Query("SELECT COUNT(cm) > 0 FROM ChatMember cm " +
             "WHERE cm.chatRoom.chatroomId = :chatRoomId AND cm.member.memberId = :memberId AND cm.isDeleted = 'FALSE'")
     boolean existsByChatRoomIdAndMemberId(@Param("chatRoomId") Long chatRoomId, @Param("memberId") Long memberId);
+
+    @Query("SELECT COUNT(cm) > 0 FROM ChatMember cm " +
+            "WHERE cm.chatRoom.chatroomId = :chatRoomId AND cm.member.email = :email AND cm.isDeleted = 'FALSE'")
+    boolean existsByChatRoomIdAndEmail(@Param("chatRoomId") Long chatRoomId, @Param("email") String email);
 }

--- a/src/main/java/team9/ddang/chat/service/ChatRoomService.java
+++ b/src/main/java/team9/ddang/chat/service/ChatRoomService.java
@@ -2,11 +2,12 @@ package team9.ddang.chat.service;
 
 import team9.ddang.chat.service.request.ChatRoomCreateServiceRequest;
 import team9.ddang.chat.service.response.ChatRoomResponse;
+import team9.ddang.member.entity.Member;
 
 import java.util.List;
 
 public interface ChatRoomService {
-    ChatRoomResponse createChatRoom(ChatRoomCreateServiceRequest request);
+    ChatRoomResponse createChatRoom(ChatRoomCreateServiceRequest request, Member member);
 
-    List<ChatRoomResponse> getChatRoomsForAuthenticatedMember();
+    List<ChatRoomResponse> getChatRoomsForAuthenticatedMember(Member member);
 }

--- a/src/main/java/team9/ddang/chat/service/ChatService.java
+++ b/src/main/java/team9/ddang/chat/service/ChatService.java
@@ -3,16 +3,17 @@ package team9.ddang.chat.service;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import team9.ddang.chat.service.request.ChatServiceRequest;
+import team9.ddang.chat.service.response.ChatReadResponse;
 import team9.ddang.chat.service.response.ChatResponse;
 import team9.ddang.member.entity.Member;
 
 public interface ChatService {
-    // TODO 나중에는 SpringSequrity에서 맴버 객체 받아서 사용할 예정
+
     ChatResponse saveChat(Long chatRoomId, String email, String message);
 
     Slice<ChatResponse> findChatsByRoom(Long chatRoomId, Pageable pageable, Member member);
 
-    void updateMessageReadStatus(Long chatRoomId);
+    ChatReadResponse updateMessageReadStatus(Long chatRoomId, String email);
 
     void checkChat(ChatServiceRequest request);
 }

--- a/src/main/java/team9/ddang/chat/service/ChatService.java
+++ b/src/main/java/team9/ddang/chat/service/ChatService.java
@@ -2,15 +2,17 @@ package team9.ddang.chat.service;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import team9.ddang.chat.service.request.ChatServiceRequest;
 import team9.ddang.chat.service.response.ChatResponse;
+import team9.ddang.member.entity.Member;
 
 public interface ChatService {
     // TODO 나중에는 SpringSequrity에서 맴버 객체 받아서 사용할 예정
-    ChatResponse saveChat(Long chatRoomId, Long memberId, String message);
+    ChatResponse saveChat(Long chatRoomId, String email, String message);
 
-    Slice<ChatResponse> findChatsByRoom(Long chatRoomId, Pageable pageable);
+    Slice<ChatResponse> findChatsByRoom(Long chatRoomId, Pageable pageable, Member member);
 
     void updateMessageReadStatus(Long chatRoomId);
 
-    void checkChat(Long chatRoomId);
+    void checkChat(ChatServiceRequest request);
 }

--- a/src/main/java/team9/ddang/chat/service/ChatServiceImpl.java
+++ b/src/main/java/team9/ddang/chat/service/ChatServiceImpl.java
@@ -12,9 +12,12 @@ import team9.ddang.chat.entity.ChatType;
 import team9.ddang.chat.event.MessageReadEvent;
 import team9.ddang.chat.exception.ChatExceptionMessage;
 import team9.ddang.chat.producer.ChatProducer;
+import team9.ddang.chat.repository.ChatMemberRepository;
 import team9.ddang.chat.repository.ChatRepository;
 import team9.ddang.chat.repository.ChatRoomRepository;
+import team9.ddang.chat.service.request.ChatServiceRequest;
 import team9.ddang.chat.service.response.ChatResponse;
+import team9.ddang.family.exception.FamilyExceptionMessage;
 import team9.ddang.member.entity.Member;
 import team9.ddang.member.repository.MemberRepository;
 
@@ -29,15 +32,15 @@ public class ChatServiceImpl implements ChatService {
     private final ChatRoomRepository chatRoomRepository;
     private final MemberRepository memberRepository;
     private final ChatProducer chatProducer;
+    private final ChatMemberRepository chatMemberRepository;
 
     @Override
     @Transactional
-    public ChatResponse saveChat(Long chatRoomId, Long memberId, String message) {
+    public ChatResponse saveChat(Long chatRoomId, String email, String message) {
 
         ChatRoom chatRoom = findChatRoomByIdOrThrowException(chatRoomId);
 
-        // TODO 나중에는 SpringSequrity에서 맴버 객체 받아서 사용할 예정
-        Member member = memberRepository.findById(memberId).orElseThrow();
+        Member member = findMemberByEmailOrThrowException(email);
 
         Chat chat = Chat.builder()
                 .chatRoom(chatRoom)
@@ -52,16 +55,19 @@ public class ChatServiceImpl implements ChatService {
 
     @Override
     @Transactional
-    public Slice<ChatResponse> findChatsByRoom(Long chatRoomId, Pageable pageable) {
-        // TODO 나중에는 SpringSequrity에서 맴버 객체 받아서 사용할 예정
-        Long memberId = 2L;
+    public Slice<ChatResponse> findChatsByRoom(Long chatRoomId, Pageable pageable, Member member) {
 
-        // TODO 나중에 Member가 해당 채팅방에 속해있는지 검증 필요
+        Member currentMember = findMemberByIdOrThrowException(member.getMemberId());
+
         findChatRoomByIdOrThrowException(chatRoomId);
+
+        if(!chatMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, currentMember.getMemberId())){
+            throw new IllegalArgumentException(ChatExceptionMessage.CHATMEMBER_NOT_IN_CHATROOM.getText());
+        }
 
         Slice<Chat> chats = chatRepository.findByChatRoomId(chatRoomId, pageable);
 
-        List<Chat> unreadChats = chatRepository.findUnreadMessagesByChatRoomIdAndMemberId(chatRoomId, memberId);
+        List<Chat> unreadChats = chatRepository.findUnreadMessagesByChatRoomIdAndMemberId(chatRoomId, currentMember.getMemberId());
 
         if (unreadChats.isEmpty()) {
             return chats.map(ChatResponse::new);
@@ -70,7 +76,7 @@ public class ChatServiceImpl implements ChatService {
         unreadChats.forEach(Chat::markAsRead);
 
         String topic = "topic-chat-" + chatRoomId;
-        MessageReadEvent readEvent = new MessageReadEvent(chatRoomId, memberId, null);
+        MessageReadEvent readEvent = new MessageReadEvent(chatRoomId, currentMember.getMemberId(), null);
         chatProducer.sendReadEvent(topic, readEvent);
 
         return chats.map(ChatResponse::new);
@@ -99,8 +105,9 @@ public class ChatServiceImpl implements ChatService {
         chatProducer.sendReadEvent(topicName, readEvent);
     }
 
-    public void checkChat(Long chatRoomId){
-        findChatRoomByIdOrThrowException(chatRoomId);
+    public void checkChat(ChatServiceRequest request){
+        findChatRoomByIdOrThrowException(request.chatRoomId());
+        findMemberByEmailOrThrowException(request.email());
     }
 
     private ChatRoom findChatRoomByIdOrThrowException(Long id) {
@@ -108,6 +115,22 @@ public class ChatServiceImpl implements ChatService {
                 .orElseThrow(() -> {
                     log.warn(">>>> {} : {} <<<<", id, ChatExceptionMessage.CHATROOM_NOT_FOUND);
                     return new IllegalArgumentException(ChatExceptionMessage.CHATROOM_NOT_FOUND.getText());
+                });
+    }
+
+    private Member findMemberByEmailOrThrowException(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> {
+                    log.warn(">>>> {} : {} <<<<", email, ChatExceptionMessage.MEMBER_NOT_FOUND);
+                    return new IllegalArgumentException(ChatExceptionMessage.MEMBER_NOT_FOUND.getText());
+                });
+    }
+
+    private Member findMemberByIdOrThrowException(Long id) {
+        return memberRepository.findActiveById(id)
+                .orElseThrow(() -> {
+                    log.warn(">>>> {} : {} <<<<", id, FamilyExceptionMessage.MEMBER_NOT_FOUND);
+                    return new IllegalArgumentException(FamilyExceptionMessage.MEMBER_NOT_FOUND.getText());
                 });
     }
 }

--- a/src/main/java/team9/ddang/chat/service/request/ChatReadServiceRequest.java
+++ b/src/main/java/team9/ddang/chat/service/request/ChatReadServiceRequest.java
@@ -1,0 +1,10 @@
+package team9.ddang.chat.service.request;
+
+import java.util.List;
+
+public record ChatReadServiceRequest(
+        Long chatRoomId,
+        String email,
+        List<Long> readMessageIds
+) {
+}

--- a/src/main/java/team9/ddang/chat/service/request/ChatServiceRequest.java
+++ b/src/main/java/team9/ddang/chat/service/request/ChatServiceRequest.java
@@ -2,5 +2,6 @@ package team9.ddang.chat.service.request;
 
 public record ChatServiceRequest(
         Long chatRoomId,
+        String email,
         String message) {
 }

--- a/src/main/java/team9/ddang/chat/service/request/ChatServiceRequest.java
+++ b/src/main/java/team9/ddang/chat/service/request/ChatServiceRequest.java
@@ -1,7 +1,6 @@
 package team9.ddang.chat.service.request;
 
 public record ChatServiceRequest(
-        Long memberId,
         Long chatRoomId,
         String message) {
 }

--- a/src/main/java/team9/ddang/chat/service/response/ChatReadResponse.java
+++ b/src/main/java/team9/ddang/chat/service/response/ChatReadResponse.java
@@ -1,11 +1,11 @@
-package team9.ddang.chat.event;
+package team9.ddang.chat.service.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.util.List;
 
 @Schema(description = "메시지 읽음 이벤트 데이터")
-public record MessageReadEvent(
+public record ChatReadResponse(
 
         @Schema(description = "채팅방 ID", example = "1")
         Long chatRoomId,

--- a/src/main/java/team9/ddang/chat/service/response/ChatRoomResponse.java
+++ b/src/main/java/team9/ddang/chat/service/response/ChatRoomResponse.java
@@ -2,6 +2,10 @@ package team9.ddang.chat.service.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import team9.ddang.chat.entity.ChatRoom;
+import team9.ddang.member.entity.Member;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Schema(description = "채팅방 응답 데이터")
 public record ChatRoomResponse(
@@ -13,18 +17,19 @@ public record ChatRoomResponse(
         @Schema(description = "마지막 메시지", example = "안녕하세요!")
         String lastMessage,
         @Schema(description = "읽지 않은 메시지 개수", example = "3")
-        Long unreadMessageCount
-//        List<MemberResponse> members
+        Long unreadMessageCount,
+        @Schema(description = "채팅방 참여자")
+        List<ChatMemberInfo> members
 ) {
-    public ChatRoomResponse(ChatRoom chatRoom, String lastMessage, Long unreadMessageCount) {
+    public ChatRoomResponse(ChatRoom chatRoom, String lastMessage, Long unreadMessageCount, List<Member> members) {
         this(
                 chatRoom.getChatroomId(),
                 chatRoom.getName(),
                 lastMessage,
-                unreadMessageCount
-//                members.stream()
-//                        .map(MemberResponse::new)
-//                        .collect(Collectors.toList())
+                unreadMessageCount,
+                members.stream()
+                        .map(ChatMemberInfo::new)
+                        .collect(Collectors.toList())
         );
     }
 }

--- a/src/main/java/team9/ddang/family/controller/FamilyController.java
+++ b/src/main/java/team9/ddang/family/controller/FamilyController.java
@@ -30,6 +30,7 @@ public class FamilyController {
             description = """
                     새로운 가족을 생성하고, 생성된 가족 정보를 반환합니다.
                     요청 본문에는 가족 이름(familyName)이 포함되어야 합니다.
+                    강아지를 소유하고, 패밀리댕에 속해 있지 않은 맴버만 생성할 수 있습니다.
                     """,
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "가족 생성 요청 데이터",
@@ -37,33 +38,7 @@ public class FamilyController {
                             mediaType = "application/json",
                             schema = @Schema(implementation = FamilyCreateRequest.class)
                     )
-            ),
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "가족 생성 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = FamilyResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "400",
-                            description = "잘못된 요청 데이터",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    )
-            }
+            )
     )
     public ApiResponse<FamilyResponse> createFamily(@RequestBody FamilyCreateRequest request, @AuthenticationPrincipal CustomOAuth2User currentUser) {
         Member currentMember = currentUser.getMember();
@@ -79,33 +54,7 @@ public class FamilyController {
                     지정된 가족에 대한 5분 유효기간의 초대 코드를 생성합니다.
                     생성된 초대 코드는 반환되며, 5분 후에 만료됩니다.
                     이미 초대 코드가 있는 경우, 남은 유효기간과 함께 초대 코드를 반환합니다.
-                    """,
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "초대 코드 생성 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = InviteCodeResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "가족이 존재하지 않음",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    )
-            }
+                    """
     )
     public ApiResponse<InviteCodeResponse> createInviteCode(@AuthenticationPrincipal CustomOAuth2User currentUser) {
         Member currentMember = currentUser.getMember();
@@ -126,33 +75,7 @@ public class FamilyController {
                             mediaType = "application/json",
                             schema = @Schema(implementation =FamilyJoinRequest.class)
                     )
-            ),
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "가족 참여 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = FamilyResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "400",
-                            description = "잘못된 요청 데이터 또는 초대 코드 만료",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    )
-            }
+            )
     )
     public ApiResponse<FamilyResponse> joinFamily(@RequestBody FamilyJoinRequest request,
                                                   @AuthenticationPrincipal CustomOAuth2User currentUser) {
@@ -166,33 +89,7 @@ public class FamilyController {
             summary = "내 가족 정보 조회",
             description = """
                 로그인한 사용자가 속한 가족 정보를 조회합니다.
-                """,
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "200",
-                            description = "가족 정보 조회 성공",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = FamilyDetailResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "가족 정보가 없습니다.",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "500",
-                            description = "서버 오류",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    )
-            }
+                """
     )
     public ApiResponse<FamilyDetailResponse> getMyFamily(@AuthenticationPrincipal CustomOAuth2User currentUser) {
         Member currentMember = currentUser.getMember();
@@ -206,29 +103,7 @@ public class FamilyController {
             description = """
                 가족 소유자가 특정 멤버를 가족에서 추방합니다.
                 추방 권한은 가족 소유자에게만 주어집니다.
-                """,
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "204",
-                            description = "멤버 추방 성공"
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "400",
-                            description = "권한 없음",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "멤버 또는 가족을 찾을 수 없음",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    )
-            }
+                """
     )
     public ApiResponse<Void> removeMember(
             @PathVariable Long memberId,
@@ -243,14 +118,9 @@ public class FamilyController {
     @Operation(
             summary = "가족 삭제",
             description = """
-                    가족 삭제를 수행합니다. 
+                    가족 삭제를 수행합니다.
                     가족 삭제는 가족의 주인이면서 가족 구성원이 혼자인 경우에만 가능합니다.
-                    """,
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "가족 삭제 성공"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "삭제 권한이 없거나 가족 구성원이 여러 명인 경우"),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
-            }
+                    """
     )
     public ApiResponse<Void> deleteFamily(@AuthenticationPrincipal CustomOAuth2User currentUser) {
         familyService.deleteFamily(currentUser.getMember());
@@ -263,29 +133,7 @@ public class FamilyController {
             description = """
                 현재 사용자가 가족에서 탈퇴합니다.
                 가족 소유자는 가족을 삭제해야 하며, 탈퇴할 수 없습니다.
-                """,
-            responses = {
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "204",
-                            description = "가족 탈퇴 성공"
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "400",
-                            description = "가족 소유자는 탈퇴할 수 없음",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    ),
-                    @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                            responseCode = "404",
-                            description = "사용자가 가족에 속하지 않음",
-                            content = @Content(
-                                    mediaType = "application/json",
-                                    schema = @Schema(implementation = ApiResponse.class)
-                            )
-                    )
-            }
+                """
     )
     public ApiResponse<Void> leaveFamily(@AuthenticationPrincipal CustomOAuth2User currentUser) {
         familyService.leaveFamily(currentUser.getMember());

--- a/src/main/java/team9/ddang/family/controller/request/FamilyCreateRequest.java
+++ b/src/main/java/team9/ddang/family/controller/request/FamilyCreateRequest.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 @Schema(description = "가족 생성 요청 데이터")
 public record FamilyCreateRequest(
         @NotBlank(message = "가족 이름은 필수입니다.")
-        @Schema(description = "가족 이름", example = "철수네 가족")
+        @Schema(description = "가족 이름", example = "행복한 가족")
         String familyName
 ) {
 }

--- a/src/main/java/team9/ddang/global/config/websocket/StompHandler.java
+++ b/src/main/java/team9/ddang/global/config/websocket/StompHandler.java
@@ -1,45 +1,111 @@
 package team9.ddang.global.config.websocket;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
+import team9.ddang.chat.repository.ChatMemberRepository;
+import team9.ddang.chat.repository.ChatRoomRepository;
+import team9.ddang.member.jwt.service.JwtService;
+
+import java.security.Principal;
+import java.util.Collections;
 
 @Component
 @RequiredArgsConstructor
 public class StompHandler implements ChannelInterceptor {
 
-//    private final ChatRoomRepository chatRoomRepository;
-//    private final ChatMemberRepository chatMemberRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final ChatMemberRepository chatMemberRepository;
+    private final JwtService jwtService;
 
-//    @Override
-//    public Message<?> preSend(Message<?> message, MessageChannel channel) {
-//        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
-//
-//        if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
-//            String destination = accessor.getDestination(); // 예: /sub/chat/{chatRoomId}
-//            Long chatRoomId = extractChatRoomId(destination);
-//
-//            Principal principal = accessor.getUser();
-//            if (principal == null) {
-//                throw new AccessDeniedException("인증되지 않은 사용자입니다.");
-//            }
-//
-//            Long memberId = Long.valueOf(principal.getName());
-//
-//            boolean isParticipant = chatMemberRepository.existsByChatRoomIdAndMemberId(chatRoomId, memberId);
-//            if (!isParticipant) {
-//                throw new AccessDeniedException("해당 채팅방에 접근할 권한이 없습니다.");
-//            }
-//        }
-//
-//        return message;
-//    }
-//
-//    private Long extractChatRoomId(String destination) {
-//        return Long.parseLong(destination.split("/chat/")[1]);
-//    }
+    @Override
+    public Message<?> preSend(Message<?> message, MessageChannel channel) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.wrap(message);
 
+        try {
+            if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                handleConnect(accessor);
+            }
+
+            if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+                handleSubscribe(accessor);
+            }
+        } catch (Exception e) {
+            System.err.println("Error in StompHandler: " + e.getMessage());
+            e.printStackTrace();
+            throw e;
+        }
+
+        return message;
+    }
+
+    private void handleConnect(StompHeaderAccessor accessor) {
+        String token = extractToken(accessor);
+
+        if (token == null || !jwtService.isTokenValid(token)) {
+            throw new IllegalArgumentException("유효하지 않은 토큰입니다.");
+        }
+
+        String email = jwtService.extractEmail(token)
+                .orElseThrow(() -> new IllegalArgumentException("토큰에서 이메일을 추출할 수 없습니다."));
+
+        Authentication authentication = new UsernamePasswordAuthenticationToken(email, null, Collections.emptyList());
+        accessor.setUser(authentication);
+
+        accessor.getSessionAttributes().put("user", authentication);
+
+        System.out.println("User connected: " + email);
+    }
+
+    private void handleSubscribe(StompHeaderAccessor accessor) {
+        Principal principal = accessor.getUser();
+
+        if (principal == null) {
+            principal = (Principal) accessor.getSessionAttributes().get("user");
+        }
+
+        if (principal == null) {
+            throw new IllegalArgumentException("구독 요청 시 인증되지 않은 사용자입니다.");
+        }
+
+        String email = principal.getName();
+        System.out.println("User subscribing: " + email);
+
+        String destination = accessor.getDestination();
+        if (destination != null && destination.startsWith("/sub/chat/")) {
+            Long chatRoomId = extractChatRoomId(destination);
+
+            boolean isParticipant = chatMemberRepository.existsByChatRoomIdAndEmail(chatRoomId, email);
+            if (!isParticipant) {
+                throw new IllegalArgumentException("해당 채팅방에 접근할 권한이 없습니다.");
+            }
+        }
+    }
+
+    private Long extractChatRoomId(String destination) {
+        if (destination == null || !destination.contains("/chat/")) {
+            throw new IllegalArgumentException("잘못된 구독 경로입니다: " + destination);
+        }
+        try {
+            return Long.parseLong(destination.split("/chat/")[1]);
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("채팅방 ID를 파싱할 수 없습니다: " + destination, e);
+        }
+    }
+
+    private String extractToken(SimpMessageHeaderAccessor accessor) {
+        String authHeader = accessor.getFirstNativeHeader("Authorization");
+        System.out.println("Authorization header: " + authHeader);
+        if (authHeader != null && authHeader.startsWith("Bearer ")) {
+            return authHeader.substring(7);
+        }
+        throw new IllegalArgumentException("Authorization 헤더가 없거나 잘못되었습니다.");
+    }
 }
-
-// TODO : jwt 인증 절차 필요
-// TODO : 시큐리티 완료시 구독 유효성 검증 활성화시키기

--- a/src/main/java/team9/ddang/global/config/websocket/WebSocketConfig.java
+++ b/src/main/java/team9/ddang/global/config/websocket/WebSocketConfig.java
@@ -29,7 +29,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
                 .setAllowedOriginPatterns("*");
 //                .withSockJS();
     }
-
+    @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
 //        registration.interceptors(stompHandler);
     }

--- a/src/main/java/team9/ddang/global/config/websocket/WebSocketConfig.java
+++ b/src/main/java/team9/ddang/global/config/websocket/WebSocketConfig.java
@@ -31,6 +31,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     }
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {
-//        registration.interceptors(stompHandler);
+        registration.interceptors(stompHandler);
     }
 }

--- a/src/main/java/team9/ddang/global/controller/WebSocketController.java
+++ b/src/main/java/team9/ddang/global/controller/WebSocketController.java
@@ -9,9 +9,9 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team9.ddang.chat.controller.request.ChatReadRequest;
 import team9.ddang.chat.controller.request.ChatRequest;
-import team9.ddang.chat.event.MessageReadEvent;
 import team9.ddang.chat.service.response.ChatReadResponse;
 import team9.ddang.chat.service.response.ChatResponse;
+import team9.ddang.global.api.WebSocketResponse;
 import team9.ddang.global.controller.response.WebSocketErrorResponse;
 
 @Tag(name = "WebSocket Chat API", description = "WebSocket을 통한 채팅 관련 명세")
@@ -20,7 +20,7 @@ public class WebSocketController {
 
     @Operation(
             summary = "채팅 메시지 전송",
-            description = "WebSocket을 통해 채팅 메시지를 전송합니다. 메시지를 전송하려면 '/pub/api/v1/chat/message' 경로로 JSON 데이터를 전송하세요. 시큐리티 완성 시, 요청 데이터에서 memberId는 제외될 예정입니다.",
+            description = "WebSocket을 통해 채팅 메시지를 전송합니다. 메시지를 전송하려면 '/pub/api/v1/chat/message' 경로로 JSON 데이터를 전송하세요. /sub/chat/{chatRoomId} 구독 경로로 메세지를 broadcast 합니다.",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "채팅 메시지 요청 데이터",
                     content = @Content(
@@ -30,16 +30,16 @@ public class WebSocketController {
             ),
             responses = {
                     @ApiResponse(
-                            responseCode = "200",
-                            description = "Kafka 브로드캐스트 메시지",
+                            responseCode = "400",
+                            description = "잘못된 요청 (유효성 검사 실패 또는 기타 클라이언트 오류)",
                             content = @Content(
                                     mediaType = "application/json",
-                                    schema = @Schema(implementation = ChatResponse.class)
+                                    schema = @Schema(implementation = WebSocketErrorResponse.class)
                             )
                     ),
                     @ApiResponse(
-                            responseCode = "400",
-                            description = "잘못된 요청 (유효성 검사 실패 또는 기타 클라이언트 오류)",
+                            responseCode = "500",
+                            description = "서버 에러 (감지하지 못한 서버 에러)",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = WebSocketErrorResponse.class)
@@ -48,12 +48,14 @@ public class WebSocketController {
             }
     )
     @GetMapping("/docs/ws/api/v1/chat/message")
-    public void sendMessage() {
+    public WebSocketResponse<ChatResponse> sendMessage() {
+        ChatResponse chatResponse = null;
+        return WebSocketResponse.ok(chatResponse);
     }
 
     @Operation(
             summary = "메시지 읽음 처리",
-            description = "WebSocket을 통해 메시지 읽음 상태를 업데이트합니다. 읽음 처리를 위해 '/pub/api/v1/chat/ack/{chatRoomId}' 경로로 JSON 데이터를 전송하세요.",
+            description = "WebSocket을 통해 메시지 읽음 상태를 업데이트합니다. 읽음 처리를 위해 '/pub/api/v1/chat/ack/{chatRoomId}' 경로로 JSON 데이터를 전송하세요. /sub/chat/{chatRoomId} 구독 경로로 메세지 읽음 여부를 broadcast 합니다.",
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "메시지 읽음 요청 데이터",
                     content = @Content(
@@ -63,16 +65,16 @@ public class WebSocketController {
             ),
             responses = {
                     @ApiResponse(
-                            responseCode = "200",
-                            description = "Kafka를 통해 브로드캐스트된 읽음 상태",
+                            responseCode = "400",
+                            description = "잘못된 요청 (유효성 검사 실패 또는 기타 클라이언트 오류)",
                             content = @Content(
                                     mediaType = "application/json",
-                                    schema = @Schema(implementation = ChatReadResponse.class)
+                                    schema = @Schema(implementation = WebSocketErrorResponse.class)
                             )
                     ),
                     @ApiResponse(
-                            responseCode = "400",
-                            description = "잘못된 요청 (유효성 검사 실패 또는 기타 클라이언트 오류)",
+                            responseCode = "500",
+                            description = "서버 에러 (감지하지 못한 서버 에러)",
                             content = @Content(
                                     mediaType = "application/json",
                                     schema = @Schema(implementation = WebSocketErrorResponse.class)
@@ -81,6 +83,8 @@ public class WebSocketController {
             }
     )
     @GetMapping("/docs/ws/api/v1/chat/ack")
-    public void handleMessageAck() {
+    public WebSocketResponse<ChatReadResponse> handleMessageAck() {
+        ChatReadResponse chatReadResponse = null;
+        return WebSocketResponse.ok(chatReadResponse);
     }
 }

--- a/src/main/java/team9/ddang/global/controller/WebSocketController.java
+++ b/src/main/java/team9/ddang/global/controller/WebSocketController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import team9.ddang.chat.controller.request.ChatReadRequest;
 import team9.ddang.chat.controller.request.ChatRequest;
 import team9.ddang.chat.event.MessageReadEvent;
+import team9.ddang.chat.service.response.ChatReadResponse;
 import team9.ddang.chat.service.response.ChatResponse;
 import team9.ddang.global.controller.response.WebSocketErrorResponse;
 
@@ -66,7 +67,7 @@ public class WebSocketController {
                             description = "Kafka를 통해 브로드캐스트된 읽음 상태",
                             content = @Content(
                                     mediaType = "application/json",
-                                    schema = @Schema(implementation = MessageReadEvent.class)
+                                    schema = @Schema(implementation = ChatReadResponse.class)
                             )
                     ),
                     @ApiResponse(

--- a/src/main/java/team9/ddang/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/team9/ddang/global/exception/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package team9.ddang.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSourceResolvable;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -45,7 +46,7 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HandlerMethodValidationException.class)
     public ApiResponse<Object> handleHandlerMethodValidationException(HandlerMethodValidationException e) {
         String message = e.getAllErrors().stream()
-                .map(error -> error.getDefaultMessage())
+                .map(MessageSourceResolvable::getDefaultMessage)
                 .collect(Collectors.joining(", "));
 
         log.error("HandlerMethodValidationException : {}", e.getMessage());

--- a/src/main/java/team9/ddang/global/exception/WebSocketExceptionHandler.java
+++ b/src/main/java/team9/ddang/global/exception/WebSocketExceptionHandler.java
@@ -1,52 +1,64 @@
 package team9.ddang.global.exception;
 
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.MessageSourceResolvable;
+import org.springframework.context.support.DefaultMessageSourceResolvable;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
-import org.springframework.messaging.handler.annotation.SendTo;
 import org.springframework.messaging.handler.annotation.support.MethodArgumentNotValidException;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.method.annotation.HandlerMethodValidationException;
+import team9.ddang.global.api.WebSocketResponse;
 
 import java.util.stream.Collectors;
 
 @ControllerAdvice
 @Slf4j
 public class WebSocketExceptionHandler {
+
     @MessageExceptionHandler(BindException.class)
     @SendToUser("/queue/errors")
-    public String handleBindException(BindException e) {
+    public WebSocketResponse<String> handleBindException(BindException e) {
         log.error("WebSocket BindException: {}", e.getMessage());
-        return "유효성 검사 실패: " + e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        String errorMessage = "유효성 검사 실패: " + e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return WebSocketResponse.of(4001, errorMessage, null);
     }
 
     @MessageExceptionHandler(IllegalArgumentException.class)
-    @SendTo("/queue/errors")
-    public String handleIllegalArgumentException(IllegalArgumentException e) {
+    @SendToUser("/queue/errors")
+    public WebSocketResponse<String> handleIllegalArgumentException(IllegalArgumentException e) {
         log.error("WebSocket IllegalArgumentException: {}", e.getMessage());
-        return "잘못된 요청: " + e.getMessage();
+        return WebSocketResponse.of(4002, "잘못된 요청: " + e.getMessage(), null);
     }
 
     @MessageExceptionHandler(HandlerMethodValidationException.class)
     @SendToUser("/queue/errors")
-    public String handleHandlerMethodValidationException(HandlerMethodValidationException e) {
+    public WebSocketResponse<String> handleHandlerMethodValidationException(HandlerMethodValidationException e) {
         String message = e.getAllErrors().stream()
-                .map(error -> error.getDefaultMessage())
+                .map(MessageSourceResolvable::getDefaultMessage)
                 .collect(Collectors.joining(", "));
 
         log.error("WebSocket HandlerMethodValidationException: {}", message);
-        return "유효성 검사 실패: " + message;
+        return WebSocketResponse.of(4003, "유효성 검사 실패: " + message, null);
     }
 
     @MessageExceptionHandler(MethodArgumentNotValidException.class)
-    @SendTo("/queue/errors")
-    public String handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    @SendToUser("/queue/errors")
+    public WebSocketResponse<String> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        assert e.getBindingResult() != null;
         String message = e.getBindingResult().getAllErrors().stream()
-                .map(error -> error.getDefaultMessage())
+                .map(DefaultMessageSourceResolvable::getDefaultMessage)
                 .collect(Collectors.joining(", "));
 
         log.error("WebSocket MethodArgumentNotValidException: {}", message);
-        return "유효성 검사 실패: " + message;
+        return WebSocketResponse.of(4004, "유효성 검사 실패: " + message, null);
+    }
+
+    @MessageExceptionHandler(Exception.class)
+    @SendToUser("/queue/errors")
+    public WebSocketResponse<String> handleGeneralException(Exception e) {
+        log.error("WebSocket Exception: {}", e.getMessage());
+        return WebSocketResponse.of(5000, "서버 내부 오류: " + e.getMessage(), null);
     }
 }

--- a/src/main/java/team9/ddang/member/repository/MemberRepository.java
+++ b/src/main/java/team9/ddang/member/repository/MemberRepository.java
@@ -11,7 +11,8 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
 
-    Optional<Member> findByEmail(String email);
+    @Query("SELECT m FROM Member m WHERE m.email = :email AND m.isDeleted = 'FALSE'")
+    Optional<Member> findByEmail(@Param("email") String email);
 
     @Query("SELECT m FROM Member m WHERE m.memberId = :id AND m.isDeleted = 'FALSE'")
     Optional<Member> findActiveById(@Param("id") Long id);


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- 채팅, 채팅방 API에서 시큐리티에서 받아온 맴버 사용하도록 수정
- 메세지 읽음 처리를 비동기로 변경
- 웹소켓 연결 및 채팅방 구독에 대한 검증을 StompHandler에 추가

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #23
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
WebSocket 통신에서 CONNECT 요청 시 JWT를 검증하고 사용자 인증을 수행하고,
SUBSCRIBE 요청 시 사용자가 구독하려는 채팅방에 대한 접근 권한을 검사하는 STOMP 핸들러를 작성했습니다.

STOMP 핸들러가 역할은 잘 수행하고 있지만, 예외가 발생했을 때 이를 적절히 핸들링하지 못해 오류 메시지를 클라이언트에게 전달하지 못하고, 특히 구독 요청이 적절하지 않으면 그냥 웹소켓 연결을 끊어버립니다.

Spring WebSocket은 STOMP 명령 처리 중 예외가 발생하면 기본적으로 WebSocket 세션을 종료합니다. 이는  서버 리소스를 보호하기 위한 조치입니다.

그래서 에러 메세지를 user/queue/error 에 태워 보내기 전에 웹소켓 연결이 끊어져서 에러 메세지를 보내지 못합니다.

그러던 와중 명세 작업 중에 WalkSchedule이 없는 점을 깨닫고, 일단 다음 PR로 넘기려고 합니다.
일단 구독 경로 검증은 chat에만 적용해서, 재경님 코드 동작에는 문제 없을 것 같습니다.