### PR TITLE
[Feat/#47] dog crud extend logic

### DIFF
--- a/src/main/java/team9/ddang/dog/controller/DogController.java
+++ b/src/main/java/team9/ddang/dog/controller/DogController.java
@@ -34,13 +34,10 @@ public class DogController {
 
     @GetMapping("/{id}")
     public ApiResponse<GetDogResponse> getMyDog(
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-
-        // 로그인된 사용자 ID 가져오기
-        Long memberId = customOAuth2User.getMember().getMemberId();
+            @PathVariable Long id) {
 
         // 서비스 호출
-        GetDogResponse response = dogService.getDogByMemberId(memberId);
+        GetDogResponse response = dogService.getDogByDogId(id);
 
         // ApiResponse로 바로 반환
         return ApiResponse.ok(response);

--- a/src/main/java/team9/ddang/dog/controller/request/CreateDogRequest.java
+++ b/src/main/java/team9/ddang/dog/controller/request/CreateDogRequest.java
@@ -5,6 +5,7 @@ import team9.ddang.dog.service.request.CreateDogServiceRequest;
 import team9.ddang.global.entity.Gender;
 import team9.ddang.dog.entity.IsNeutered;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record CreateDogRequest(
@@ -19,15 +20,17 @@ public record CreateDogRequest(
         @Past(message = "생년월일은 과거 날짜여야 합니다.")
         LocalDate birthDate,
 
-        @Min(value = 1, message = "몸무게는 최소 1kg 이상이어야 합니다.")
-        @Max(value = 100, message = "몸무게는 최대 100kg 이하여야 합니다.")
-        Integer weight,
+        @DecimalMin(value = "1.00", message = "몸무게는 최소 1kg 이상이어야 합니다.")
+        @DecimalMax(value = "100.00", message = "몸무게는 최대 100kg 이하여야 합니다.")
+        @Digits(integer = 3, fraction = 2, message = "몸무게는 소수점 둘째 자리까지만 가능합니다.")
+        BigDecimal weight,
 
         @NotNull(message = "성별은 반드시 입력해야 합니다.")
         Gender gender,
 
         String profileImg,
 
+        @NotNull(message = "중성화 여부는 반드시 입력해야 합니다.")
         IsNeutered isNeutered,
 
         Long familyId,

--- a/src/main/java/team9/ddang/dog/controller/request/UpdateDogRequest.java
+++ b/src/main/java/team9/ddang/dog/controller/request/UpdateDogRequest.java
@@ -5,6 +5,7 @@ import team9.ddang.dog.service.request.UpdateDogServiceRequest;
 import team9.ddang.global.entity.Gender;
 import team9.ddang.dog.entity.IsNeutered;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.Optional;
 
@@ -20,15 +21,17 @@ public record UpdateDogRequest(
         @Past(message = "생년월일은 과거 날짜여야 합니다.")
         LocalDate birthDate,
 
-        @Min(value = 1, message = "몸무게는 최소 1kg 이상이어야 합니다.")
-        @Max(value = 100, message = "몸무게는 최대 100kg 이하여야 합니다.")
-        Integer weight,
+        @DecimalMin(value = "1.00", message = "몸무게는 최소 1kg 이상이어야 합니다.")
+        @DecimalMax(value = "100.00", message = "몸무게는 최대 100kg 이하여야 합니다.")
+        @Digits(integer = 3, fraction = 2, message = "몸무게는 소수점 둘째 자리까지만 가능합니다.")
+        BigDecimal weight,
 
         @NotNull(message = "성별은 반드시 입력해야 합니다.")
         Gender gender,
 
         String profileImg,
 
+        @NotNull(message = "중성화 여부는 반드시 입력해야 합니다.")
         IsNeutered isNeutered,
 
         Long familyId,

--- a/src/main/java/team9/ddang/dog/controller/request/UpdateDogRequest.java
+++ b/src/main/java/team9/ddang/dog/controller/request/UpdateDogRequest.java
@@ -34,8 +34,6 @@ public record UpdateDogRequest(
         @NotNull(message = "중성화 여부는 반드시 입력해야 합니다.")
         IsNeutered isNeutered,
 
-        Long familyId,
-
         @Size(max = 30, message = "코멘트는 최대 30자까지 입력 가능합니다.")
         String comment
 ) {
@@ -49,7 +47,6 @@ public record UpdateDogRequest(
                 gender,
                 profileImg,
                 isNeutered,
-                familyId,
                 comment
         );
     }

--- a/src/main/java/team9/ddang/dog/entity/Dog.java
+++ b/src/main/java/team9/ddang/dog/entity/Dog.java
@@ -1,6 +1,7 @@
 package team9.ddang.dog.entity;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Digits;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -10,6 +11,7 @@ import team9.ddang.global.entity.BaseEntity;
 import team9.ddang.global.entity.Gender;
 import team9.ddang.global.entity.IsDeleted;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @Entity
@@ -31,7 +33,8 @@ public class Dog extends BaseEntity {
     private LocalDate birthDate;
 
     @Column(nullable = false)
-    private Integer weight;
+    @Digits(integer = 3, fraction = 2)
+    private BigDecimal weight;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -54,7 +57,7 @@ public class Dog extends BaseEntity {
 
 
     @Builder
-    private Dog(String name, String breed, LocalDate birthDate, Gender gender, Integer weight, IsNeutered isNeutered, String profileImg, Family family, String comment) {
+    private Dog(String name, String breed, LocalDate birthDate, Gender gender, BigDecimal weight, IsNeutered isNeutered, String profileImg, Family family, String comment) {
         this.name = name;
         this.breed = breed;
         this.birthDate = birthDate;
@@ -79,7 +82,7 @@ public class Dog extends BaseEntity {
         this.birthDate = birthDate;
     }
 
-    public void updateWeight(Integer weight) {
+    public void updateWeight(BigDecimal weight) {
         this.weight = weight;
     }
 

--- a/src/main/java/team9/ddang/dog/exception/DogExceptionMessage.java
+++ b/src/main/java/team9/ddang/dog/exception/DogExceptionMessage.java
@@ -10,6 +10,8 @@ public enum DogExceptionMessage {
     // Member
     MEMBER_NOT_FOUND("해당 유저를 찾을 수 없습니다."),
     ONLY_FAMILY_OWNER_CREATE("패밀리댕 주인만 강아지를 추가할 수 있습니다."),
+    ONLY_FAMILY_OWNER_DELETE("패밀리댕 주인만 강아지를 삭제할 수 있습니다."),
+    MEMBER_NOT_HAVE_DOG("해당 강아지의 소유자가 아닙니다."),
 
     // Dog
     DOG_NOT_FOUND("해당 강아지를 찾을 수 없습니다."),

--- a/src/main/java/team9/ddang/dog/exception/DogExceptionMessage.java
+++ b/src/main/java/team9/ddang/dog/exception/DogExceptionMessage.java
@@ -1,0 +1,20 @@
+package team9.ddang.dog.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum DogExceptionMessage {
+
+    // Member
+    MEMBER_NOT_FOUND("해당 유저를 찾을 수 없습니다."),
+    ONLY_FAMILY_OWNER_CREATE("패밀리댕 주인만 강아지를 추가할 수 있습니다."),
+
+    // Dog
+    DOG_NOT_FOUND("해당 강아지를 찾을 수 없습니다."),
+    DOG_ONLY_ONE("강아지는 한마리만 소유할 수 있습니다.");
+
+
+    private final String text;
+}

--- a/src/main/java/team9/ddang/dog/repository/MemberDogRepository.java
+++ b/src/main/java/team9/ddang/dog/repository/MemberDogRepository.java
@@ -30,8 +30,8 @@ public interface MemberDogRepository extends JpaRepository<MemberDog, Long> {
     Optional<MemberDog> findOneByMemberIdAndNotDeleted(@Param("memberId") Long memberId);
 
     @Modifying
-    @Query("UPDATE MemberDog md SET md.isDeleted = 'TRUE' WHERE md.dog.dogId = :dogId AND md.member.memberId = :memberId")
-    void softDeleteByDogIdAndMemberId(@Param("dogId") Long dogId, @Param("memberId") Long memberId);
+    @Query("UPDATE MemberDog md SET md.isDeleted = 'TRUE' WHERE md.dog.dogId = :dogId")
+    void softDeleteByDogId(@Param("dogId") Long dogId);
 
 
 

--- a/src/main/java/team9/ddang/dog/service/DogService.java
+++ b/src/main/java/team9/ddang/dog/service/DogService.java
@@ -17,6 +17,7 @@ import team9.ddang.dog.entity.Dog;
 import team9.ddang.dog.repository.DogRepository;
 import team9.ddang.family.exception.FamilyExceptionMessage;
 import team9.ddang.family.repository.FamilyRepository;
+import team9.ddang.family.repository.WalkScheduleRepository;
 import team9.ddang.global.entity.IsDeleted;
 import team9.ddang.member.entity.Member;
 import team9.ddang.member.repository.MemberRepository;
@@ -37,6 +38,7 @@ public class DogService {
     private final MemberRepository memberRepository;
     private final MemberDogRepository memberDogRepository; // MemberDog 저장
     private final FamilyRepository familyRepository;
+    private final WalkScheduleRepository walkScheduleRepository;
 
     public CreateDogResponse createDog(CreateDogServiceRequest request, Long memberId) {
 
@@ -145,7 +147,7 @@ public class DogService {
 
         Member member = findMemberByIdOrThrowException(memberId);
 
-        Dog dog = findDogByIdOrThrowException(dogId);
+        findDogByIdOrThrowException(dogId);
 
         memberDogRepository.findByDogIdAndMemberId(dogId, memberId)
                 .orElseThrow(() -> new IllegalArgumentException(DogExceptionMessage.MEMBER_NOT_HAVE_DOG.getText()));
@@ -160,7 +162,9 @@ public class DogService {
         // 4. Dog 소프트 삭제
         dogRepository.softDeleteById(dogId);
 
-        // TODO 강아지 삭제하면 산책 일정도 모두 삭제하기
+        walkScheduleRepository.softDeleteByDogId(dogId);
+
+        // TODO 산책 내역 삭제하기
     }
 
     public GetDogResponse getDogByMemberId(Long memberId) {

--- a/src/main/java/team9/ddang/dog/service/request/CreateDogServiceRequest.java
+++ b/src/main/java/team9/ddang/dog/service/request/CreateDogServiceRequest.java
@@ -3,13 +3,14 @@ package team9.ddang.dog.service.request;
 import team9.ddang.global.entity.Gender;
 import team9.ddang.dog.entity.IsNeutered;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record CreateDogServiceRequest(
         String name,
         String breed,
         LocalDate birthDate,
-        Integer weight,
+        BigDecimal weight,
         Gender gender,
         String profileImg,
         IsNeutered isNeutered,

--- a/src/main/java/team9/ddang/dog/service/request/UpdateDogServiceRequest.java
+++ b/src/main/java/team9/ddang/dog/service/request/UpdateDogServiceRequest.java
@@ -15,7 +15,6 @@ public record UpdateDogServiceRequest(
         Gender gender,
         String profileImg,
         IsNeutered isNeutered,
-        Long familyId,
         String comment
 ) {}
 

--- a/src/main/java/team9/ddang/dog/service/request/UpdateDogServiceRequest.java
+++ b/src/main/java/team9/ddang/dog/service/request/UpdateDogServiceRequest.java
@@ -3,6 +3,7 @@ package team9.ddang.dog.service.request;
 import team9.ddang.global.entity.Gender;
 import team9.ddang.dog.entity.IsNeutered;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record UpdateDogServiceRequest(
@@ -10,7 +11,7 @@ public record UpdateDogServiceRequest(
         String name,
         String breed,
         LocalDate birthDate,
-        Integer weight,
+        BigDecimal weight,
         Gender gender,
         String profileImg,
         IsNeutered isNeutered,

--- a/src/main/java/team9/ddang/dog/service/response/CreateDogResponse.java
+++ b/src/main/java/team9/ddang/dog/service/response/CreateDogResponse.java
@@ -3,6 +3,7 @@ package team9.ddang.dog.service.response;
 import team9.ddang.global.entity.Gender;
 import team9.ddang.dog.entity.IsNeutered;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record CreateDogResponse(
@@ -10,7 +11,7 @@ public record CreateDogResponse(
         String name,
         String breed,
         LocalDate birthDate,
-        Integer weight,
+        BigDecimal weight,
         Gender gender,
         String profileImg,
         IsNeutered isNeutered,

--- a/src/main/java/team9/ddang/dog/service/response/GetDogResponse.java
+++ b/src/main/java/team9/ddang/dog/service/response/GetDogResponse.java
@@ -3,6 +3,7 @@ package team9.ddang.dog.service.response;
 import team9.ddang.global.entity.Gender;
 import team9.ddang.dog.entity.IsNeutered;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record GetDogResponse(
@@ -10,7 +11,7 @@ public record GetDogResponse(
         String name,
         String breed,
         LocalDate birthDate,
-        Integer weight,
+        BigDecimal weight,
         Gender gender,
         String profileImg,
         IsNeutered isNeutered,

--- a/src/main/java/team9/ddang/family/repository/WalkScheduleRepository.java
+++ b/src/main/java/team9/ddang/family/repository/WalkScheduleRepository.java
@@ -35,5 +35,5 @@ public interface WalkScheduleRepository extends JpaRepository<WalkSchedule, Long
 
     @Modifying
     @Query("UPDATE WalkSchedule w SET w.isDeleted = 'TRUE' WHERE w.dog.dogId = :dogId")
-    void softDeleteByDogId(@Param("familyId") Long dogId);
+    void softDeleteByDogId(@Param("dogId") Long dogId);
 }

--- a/src/main/java/team9/ddang/family/repository/WalkScheduleRepository.java
+++ b/src/main/java/team9/ddang/family/repository/WalkScheduleRepository.java
@@ -32,4 +32,8 @@ public interface WalkScheduleRepository extends JpaRepository<WalkSchedule, Long
     @Modifying
     @Query("UPDATE WalkSchedule w SET w.isDeleted = 'TRUE' WHERE w.family.familyId = :familyId")
     void softDeleteByFamilyId(@Param("familyId") Long familyId);
+
+    @Modifying
+    @Query("UPDATE WalkSchedule w SET w.isDeleted = 'TRUE' WHERE w.dog.dogId = :dogId")
+    void softDeleteByDogId(@Param("familyId") Long dogId);
 }

--- a/src/main/java/team9/ddang/global/config/websocket/WebSocketConfig.java
+++ b/src/main/java/team9/ddang/global/config/websocket/WebSocketConfig.java
@@ -26,8 +26,8 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(final StompEndpointRegistry registry) {
         registry
                 .addEndpoint("/ws")
-                .setAllowedOriginPatterns("*");
-//                .withSockJS();
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
     }
     @Override
     public void configureClientInboundChannel(ChannelRegistration registration) {

--- a/src/main/java/team9/ddang/member/service/response/FriendResponse.java
+++ b/src/main/java/team9/ddang/member/service/response/FriendResponse.java
@@ -8,6 +8,8 @@ import team9.ddang.member.entity.FamilyRole;
 import team9.ddang.member.entity.Member;
 import team9.ddang.walk.util.DateCalculator;
 
+import java.math.BigDecimal;
+
 public record FriendResponse(
         @Schema(description = "회원 ID", example = "1")
         Long memberId,
@@ -49,7 +51,7 @@ public record FriendResponse(
         long dogAge,
 
         @Schema(description = "강아지 무게 (킬로그램)", example = "30")
-        Integer dogWeight,
+        BigDecimal dogWeight,
 
         @Schema(description = "강아지 성별", example = "MALE")
         Gender dogGender,

--- a/src/main/java/team9/ddang/walk/util/WalkCalculator.java
+++ b/src/main/java/team9/ddang/walk/util/WalkCalculator.java
@@ -2,6 +2,7 @@ package team9.ddang.walk.util;
 
 import team9.ddang.walk.entity.Location;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -13,8 +14,8 @@ public class WalkCalculator {
 
     private WalkCalculator() {}
 
-    public static int calculateCalorie(int weight, long totalDistance){
-        return (int) (0.75 * weight * totalDistance / 1000);
+    public static int calculateCalorie(BigDecimal weight, long totalDistance){
+        return (int) (0.75 * weight.doubleValue() * totalDistance / 1000);
     }
 
     public static long calculateTime(List<Location> locations){


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- 강아지 몸무게 BigDecimal 로 수정
- 강아지 수정 리퀘스트에서 가족 제외

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #47
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
일단 S3 관련 로직은 Stash했습니다.

강아지 생성 로직을 수정했습니다.
1. 해당 맴버가 강아지를 이미 가지고 있다면 거부
2. 해당 맴버가 패밀리댕에 속해있지만, 패밀리댕의 주인이 아니라면 거부
3. 해당 맴버가 패밀리댕에 속하고, 패밀리댕의 주인이라면 해당 패밀리 인원들 모두 소유하도록

강아지 조회 로직을 수정했습니다.
1. 맴버 아이디를 받는 게 아니라, 강아지 아이디를 받아서 강아지 정보를 반환하도록 수정

강아지 업데이트 로직을 수정했습니다.
1. 더 이상 업데이트에서 패밀리댕을 받지 않습니다.

강아지 삭제 로직을 수정했습니다.
1. 해당 맴버가 패밀리댕에 속해있지만, 패밀리댕의 주인이 아니라면 거부
2. 해당 맴버가 패밀리댕에 속하고, 패밀리댕의 주인이라면 해당 패밀리 인원들로부터 소유권 제거
3. 강아지 삭제 시 패밀리댕 산책 일정 삭제
5. 강아지 삭제 시 산책 기록 삭제 (아직 못함)

생각해보니까 강아지 생성에도 패밀리를 받을 필요가 없어 보이네요. 나중에 수정하겠습니다. 지금은 일단 SocketJS가 먼저일 것 같아서....