### PR TITLE
[Feat/#46] chat family add functionality

### DIFF
--- a/src/main/java/team9/ddang/chat/controller/ChatRoomController.java
+++ b/src/main/java/team9/ddang/chat/controller/ChatRoomController.java
@@ -30,6 +30,7 @@ public class ChatRoomController {
                     새로운 채팅방을 생성하고, 채팅방 정보를 반환합니다.
                     이미 동일한 맴버와의 채팅방이 있다면, 해당 채팅방을 반환합니다.
                     요청 본문에 상대방의 회원 ID(opponentMemberId)를 포함해야 합니다.
+                    새로운 채팅방이 생성된다면, "/sub/chatroom/{opponentMemberEmail} 구독 경로로 채팅방이 생성되었음을 알립니다.
                     """,
             requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
                     description = "채팅방 생성 요청 데이터",

--- a/src/main/java/team9/ddang/chat/repository/ChatRepository.java
+++ b/src/main/java/team9/ddang/chat/repository/ChatRepository.java
@@ -46,4 +46,15 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
           AND c.isRead = 'FALSE'
     """)
     List<Chat> findUnreadMessagesByChatRoomIdAndMemberId(@Param("chatRoomId") Long chatRoomId, @Param("memberId") Long memberId);
+
+    @Query("""
+        SELECT cm.chatRoom.chatroomId, COUNT(c)
+        FROM ChatMember cm
+        LEFT JOIN Chat c ON cm.chatRoom.chatroomId = c.chatRoom.chatroomId
+        WHERE cm.member.email = :email
+          AND cm.isDeleted = 'FALSE'
+          AND (c.isRead = 'FALSE' OR c.isRead IS NULL)
+        GROUP BY cm.chatRoom.chatroomId
+       """)
+    List<Object[]> countUnreadMessagesByMemberEmail(@Param("email") String email);
 }

--- a/src/main/java/team9/ddang/chat/service/WebSocketMessageService.java
+++ b/src/main/java/team9/ddang/chat/service/WebSocketMessageService.java
@@ -1,16 +1,26 @@
 package team9.ddang.chat.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
+import team9.ddang.global.config.websocket.StompHandler;
+import team9.ddang.global.event.WebSocketMessageEvent;
 
 @Service
 @RequiredArgsConstructor
 public class WebSocketMessageService {
 
     private final SimpMessagingTemplate messagingTemplate;
+    private final StompHandler stompHandler;
 
     public void broadcastMessage(String destination, Object message) {
         messagingTemplate.convertAndSend(destination, message);
+    }
+
+    @EventListener
+    public void handleWebSocketMessageEvent(WebSocketMessageEvent event) {
+        System.out.println(event.getDestination());
+        messagingTemplate.convertAndSend(event.getDestination(), event.getPayload());
     }
 }

--- a/src/main/java/team9/ddang/family/repository/WalkScheduleRepository.java
+++ b/src/main/java/team9/ddang/family/repository/WalkScheduleRepository.java
@@ -32,4 +32,13 @@ public interface WalkScheduleRepository extends JpaRepository<WalkSchedule, Long
     @Modifying
     @Query("UPDATE WalkSchedule w SET w.isDeleted = 'TRUE' WHERE w.family.familyId = :familyId")
     void softDeleteByFamilyId(@Param("familyId") Long familyId);
+
+    @Query("""
+    SELECT w 
+    FROM WalkSchedule w
+    JOIN FETCH w.member
+    JOIN FETCH w.dog
+    WHERE w.family.familyId = :familyId AND w.isDeleted = 'FALSE'
+""")
+    List<WalkSchedule> findAllByFamilyIdWithDetails(@Param("familyId") Long familyId);
 }

--- a/src/main/java/team9/ddang/family/service/WalkScheduleServiceImpl.java
+++ b/src/main/java/team9/ddang/family/service/WalkScheduleServiceImpl.java
@@ -70,7 +70,7 @@ public class WalkScheduleServiceImpl implements WalkScheduleService {
             throw new IllegalArgumentException(FamilyExceptionMessage.MEMBER_NOT_IN_FAMILY.getText());
         }
 
-        List<WalkSchedule> schedules = walkScheduleRepository.findAllByFamilyId(currentMember.getFamily().getFamilyId());
+        List<WalkSchedule> schedules = walkScheduleRepository.findAllByFamilyIdWithDetails(currentMember.getFamily().getFamilyId());
 
         return schedules.stream()
                 .map(WalkScheduleResponse::from)

--- a/src/main/java/team9/ddang/global/controller/WebSocketController.java
+++ b/src/main/java/team9/ddang/global/controller/WebSocketController.java
@@ -101,4 +101,14 @@ public class WebSocketController {
         List<WebSocketChatInfoResponse> webSocketChatInfoResponse = null;
         return WebSocketResponse.ok(webSocketChatInfoResponse);
     }
+
+    @Operation(
+            summary = "채팅 url",
+            description = " 해당 url을 구독하면, 해당 채팅방의 채팅을 수신할 수 있습니다. 또한 다른 member 의 메세지 읽음 여부도 수신할 수 있습니다."
+    )
+    @PostMapping("/sub/chat/{chatRoomId}")
+    public WebSocketResponse<ChatResponse> recieveMessage() {
+        ChatResponse chatResponse = null;
+        return WebSocketResponse.ok(chatResponse);
+    }
 }

--- a/src/main/java/team9/ddang/global/controller/WebSocketController.java
+++ b/src/main/java/team9/ddang/global/controller/WebSocketController.java
@@ -6,13 +6,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 import team9.ddang.chat.controller.request.ChatReadRequest;
 import team9.ddang.chat.controller.request.ChatRequest;
 import team9.ddang.chat.service.response.ChatReadResponse;
 import team9.ddang.chat.service.response.ChatResponse;
 import team9.ddang.global.api.WebSocketResponse;
+import team9.ddang.global.controller.response.WebSocketChatInfoResponse;
 import team9.ddang.global.controller.response.WebSocketErrorResponse;
+
+import java.util.List;
 
 @Tag(name = "WebSocket Chat API", description = "WebSocket을 통한 채팅 관련 명세")
 @RestController
@@ -86,5 +90,15 @@ public class WebSocketController {
     public WebSocketResponse<ChatReadResponse> handleMessageAck() {
         ChatReadResponse chatReadResponse = null;
         return WebSocketResponse.ok(chatReadResponse);
+    }
+
+    @Operation(
+            summary = "채팅방 정보 url",
+            description = " 해당 url을 구독하면, 내가 속한 채팅방 목록 및 읽지 않은 메세지 개수를 받을 수 있습니다. 또한 타 유저에 의해 새로운 채팅방이 생성되면 해당 채팅방 정보를 받습니다."
+    )
+    @PostMapping("/sub/message/{email}")
+    public WebSocketResponse<List<WebSocketChatInfoResponse>> subMemberEmail(){
+        List<WebSocketChatInfoResponse> webSocketChatInfoResponse = null;
+        return WebSocketResponse.ok(webSocketChatInfoResponse);
     }
 }

--- a/src/main/java/team9/ddang/global/controller/response/WebSocketChatInfoResponse.java
+++ b/src/main/java/team9/ddang/global/controller/response/WebSocketChatInfoResponse.java
@@ -1,0 +1,11 @@
+package team9.ddang.global.controller.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record WebSocketChatInfoResponse(
+        @Schema(description = "채팅방 ID", example = "13")
+        Long chatRoomId,
+        @Schema(description = "읽지 않은 채팅 개수", example = "21")
+        Long unreadCount
+) {
+}

--- a/src/main/java/team9/ddang/global/event/WebSocketMessageEvent.java
+++ b/src/main/java/team9/ddang/global/event/WebSocketMessageEvent.java
@@ -1,0 +1,16 @@
+package team9.ddang.global.event;
+
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+@Getter
+public class WebSocketMessageEvent extends ApplicationEvent {
+    private final String destination;
+    private final Object payload;
+
+    public WebSocketMessageEvent(Object source, String destination, Object payload) {
+        super(source);
+        this.destination = destination;
+        this.payload = payload;
+    }
+}


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- /sub/message/{email} 경로 구독 검증
- 위 경로 구독 시 참여 중인 채팅방, 읽지 않은 메세지 개수 반환
- WalkSchedule N+1 문제 일부 해결

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #46 
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
일단 한번 끊고 가려고 합니다. family랑 walkschedule부분 리펙토링을 하고 있는데, family API 부분을 좀 고쳐야 할 것 같아서

특정 경로 구독 시 사용자 인증, 이밴트 발행해서 메세지 보내주는 부분, 변경된 쿼리만 리뷰하시면 될 것 같아요.
