### PR TITLE
[Feat#81] 회원 삭제 로직 개선

### DIFF
--- a/src/main/java/team9/ddang/family/service/FamilyService.java
+++ b/src/main/java/team9/ddang/family/service/FamilyService.java
@@ -1,5 +1,6 @@
 package team9.ddang.family.service;
 
+import team9.ddang.family.entity.Family;
 import team9.ddang.family.service.response.FamilyDetailResponse;
 import team9.ddang.family.service.response.FamilyResponse;
 import team9.ddang.family.service.response.InviteCodeResponse;
@@ -15,6 +16,8 @@ public interface FamilyService {
     FamilyDetailResponse getMyFamily(Member member);
 
     void removeMemberFromFamily(Long memberIdToRemove, Member member);
+
+    void deleteFamilyAndMembersAndDogs(Family family, Member currentMember);
 
     void leaveFamily(Member member);
 

--- a/src/main/java/team9/ddang/family/service/FamilyServiceImpl.java
+++ b/src/main/java/team9/ddang/family/service/FamilyServiceImpl.java
@@ -276,6 +276,27 @@ public class FamilyServiceImpl implements FamilyService {
         familyRepository.softDeleteFamilyById(family.getFamilyId());
     }
 
+    @Override
+    @Transactional
+    public void deleteFamilyAndMembersAndDogs(Family family, Member currentMember) {
+        // 가족에 속한 멤버들 방출
+        List<Member> familyMembers = memberRepository.findAllByFamilyId(family.getFamilyId());
+        for (Member familyMember : familyMembers) {
+                walkScheduleRepository.softDeleteByMemberId(familyMember.getMemberId());
+                memberDogRepository.softDeleteByMember(familyMember);
+                familyMember.updateFamily(null);
+            }
+
+        // 패밀리에 속한 강아지들 삭제
+        List<Dog> dogs = dogRepository.findAllByFamilyId(family.getFamilyId());
+        for (Dog dog : dogs) {
+            dogRepository.softDeleteById(dog.getDogId());
+        }
+
+        // 패밀리 삭제
+        familyRepository.softDeleteFamilyById(family.getFamilyId());
+    }
+
     private String generateInviteCode(Long familyId) {
         String code;
         boolean isSet;

--- a/src/main/java/team9/ddang/global/config/security/CorsConfig.java
+++ b/src/main/java/team9/ddang/global/config/security/CorsConfig.java
@@ -17,6 +17,7 @@ public class CorsConfig implements WebMvcConfigurer {
                 .allowedOrigins("https://localhost:3000", "https://localhost:3001", "https://112.162.84.70:3001")
                 .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowedHeaders("Authorization", "Content-Type")
+                .exposedHeaders("Authorization")
                 .allowCredentials(true)
                 .maxAge(3600);
     }

--- a/src/main/java/team9/ddang/member/controller/MemberController.java
+++ b/src/main/java/team9/ddang/member/controller/MemberController.java
@@ -149,8 +149,8 @@ public class MemberController {
             description = "회원을 삭제합니다."
     )
     public ApiResponse<String> deleteMember(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-        Long memberId = customOAuth2User.getMember().getMemberId();
-        memberService.deleteMember(memberId);
+
+        memberService.deleteMember(customOAuth2User.getMember());
         return ApiResponse.ok("회원 삭제 완료");
     }
 

--- a/src/main/java/team9/ddang/member/controller/MemberController.java
+++ b/src/main/java/team9/ddang/member/controller/MemberController.java
@@ -73,7 +73,7 @@ public class MemberController {
     @DeleteMapping("/logout")
     @Operation(
             summary = "로그아웃",
-            description = "로그아웃을 수행합니다."
+            description = "로그아웃을 수행합니다. 요청 시, 헤더에 유효한 `accessToken`을 `Authorization` 헤더에 `Bearer <accessToken>` 형태로 포함시켜서 보내주세요."
     )
     public ApiResponse<String> logout(HttpServletRequest request) {
         log.info("logout() 메서드 진입");

--- a/src/main/java/team9/ddang/member/jwt/service/JwtService.java
+++ b/src/main/java/team9/ddang/member/jwt/service/JwtService.java
@@ -86,7 +86,7 @@ public class JwtService {
     public void sendAccessAndRefreshToken(HttpServletResponse response, String accessToken, String refreshToken) {
         response.setStatus(HttpServletResponse.SC_OK);
 
-        setAccessTokenHeader(response, accessToken);
+        setAccessTokenHeader(response, BEARER + accessToken);
         setRefreshTokenCookie(response, refreshToken);
     }
 

--- a/src/main/java/team9/ddang/member/repository/FriendRepository.java
+++ b/src/main/java/team9/ddang/member/repository/FriendRepository.java
@@ -27,5 +27,12 @@ public interface FriendRepository  extends JpaRepository<Friend, Long> {
 """)
     void deleteBySenderAndReceiver(Member member, Member otherMember);
 
+    @Modifying
+    @Query("""
+            DELETE FROM Friend f
+            WHERE f.sender.memberId = :memberId OR f.receiver.memberId = :memberId
+            """)
+    void deleteByMemberId(Long memberId);
+
     boolean existsBySenderAndReceiver(Member sender, Member receiver);
 }

--- a/src/main/java/team9/ddang/member/service/MemberService.java
+++ b/src/main/java/team9/ddang/member/service/MemberService.java
@@ -3,6 +3,7 @@ package team9.ddang.member.service;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import team9.ddang.member.entity.IsMatched;
+import team9.ddang.member.entity.Member;
 import team9.ddang.member.service.request.JoinServiceRequest;
 import team9.ddang.member.service.request.UpdateAddressServiceRequest;
 import team9.ddang.member.service.request.UpdateServiceRequest;
@@ -26,7 +27,7 @@ public interface MemberService {
 
     UpdateResponse getUpdateInfo(Long memberId);
 
-    void deleteMember(Long memberId);
+    void deleteMember(Member member);
 
     void updateAddress(Long memberId, UpdateAddressServiceRequest serviceRequest);
 }

--- a/src/main/java/team9/ddang/member/service/MemberServiceImpl.java
+++ b/src/main/java/team9/ddang/member/service/MemberServiceImpl.java
@@ -6,11 +6,18 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import team9.ddang.dog.repository.MemberDogRepository;
 import team9.ddang.dog.service.DogService;
 import team9.ddang.dog.service.response.GetDogResponse;
+import team9.ddang.family.entity.Family;
+import team9.ddang.family.exception.FamilyExceptionMessage;
+import team9.ddang.family.repository.WalkScheduleRepository;
+import team9.ddang.family.service.FamilyService;
 import team9.ddang.member.entity.IsMatched;
 import team9.ddang.member.entity.Member;
+import team9.ddang.member.exception.MemberExceptionMessage;
 import team9.ddang.member.jwt.service.JwtService;
+import team9.ddang.member.repository.FriendRepository;
 import team9.ddang.member.repository.MemberRepository;
 import team9.ddang.member.repository.WalkWithMemberRepository;
 import team9.ddang.member.service.request.JoinServiceRequest;
@@ -30,10 +37,14 @@ public class MemberServiceImpl implements MemberService {
 
     private final MemberRepository memberRepository;
     private final WalkRepository walkRepository;
+    private final WalkScheduleRepository walkScheduleRepository;
+    private final MemberDogRepository memberDogRepository;
     private final WalkWithMemberRepository walkWithMemberRepository;
     private final DogService dogService;
     private final JwtService jwtService;
+    private final FamilyService familyService;
     private final NotificationSettingsService notificationSettingsService;
+    private final FriendRepository friendRepository;
 
     @Override
     public MemberResponse join(JoinServiceRequest serviceRequest, HttpServletResponse response) {
@@ -146,11 +157,29 @@ public class MemberServiceImpl implements MemberService {
     }
 
     @Override
-    public void deleteMember(Long memberId) {
-        memberRepository.findById(memberId)
-                .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
+    public void deleteMember(Member member) {
+        Member currentMember = findMemberByIdOrThrowException(member.getMemberId());
 
-        memberRepository.softDeleteById(memberId);
+        if (currentMember.getFamily() == null) {
+            throw new IllegalArgumentException(FamilyExceptionMessage.MEMBER_NOT_IN_FAMILY.getText());
+        }
+        Family family = currentMember.getFamily();
+
+        if (family.getMember().getMemberId().equals(currentMember.getMemberId())) { // 가족의 대표일 경우
+            familyService.deleteFamilyAndMembersAndDogs(family, currentMember);
+        } else { // 가족 구성원인 경우
+            walkScheduleRepository.softDeleteByMemberId(currentMember.getMemberId());
+            memberDogRepository.softDeleteByMember(currentMember);
+
+            currentMember.updateFamily(null);
+        }
+        notificationSettingsService.deleteNotificationSettings(currentMember.getMemberId());
+        friendRepository.deleteByMemberId(currentMember.getMemberId());
+        memberRepository.softDeleteById(currentMember.getMemberId());
+
+        if (jwtService.getRefreshTokenFromRedis(currentMember.getEmail()).isPresent()) {
+            jwtService.removeRefreshTokenFromRedis(currentMember.getEmail());
+        }
     }
 
     @Override
@@ -159,5 +188,13 @@ public class MemberServiceImpl implements MemberService {
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
         member.updateAddress(serviceRequest.address());
+    }
+
+    private Member findMemberByIdOrThrowException(Long id) {
+        return memberRepository.findActiveById(id)
+                .orElseThrow(() -> {
+                    log.warn(">>>> {} : {} <<<<", id, MemberExceptionMessage.MEMBER_NOT_FOUND);
+                    return new IllegalArgumentException(MemberExceptionMessage.MEMBER_NOT_FOUND.getText());
+                });
     }
 }

--- a/src/main/java/team9/ddang/member/service/MemberServiceImpl.java
+++ b/src/main/java/team9/ddang/member/service/MemberServiceImpl.java
@@ -112,7 +112,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public MyPageResponse getMemberInfo(Long memberId) {
 
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findActiveById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
         int totalDistanceInMeters = walkRepository.findTotalDistanceByMemberId(memberId);
@@ -128,7 +128,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public IsMatched updateIsMatched(Long memberId, IsMatched isMatched) {
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findActiveById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
         member.updateIsMatched(isMatched);
@@ -138,7 +138,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public UpdateResponse updateMember(Long memberId, UpdateServiceRequest updateServiceRequest) {
 
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findActiveById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
         updateServiceRequest.toEntity(member);
@@ -150,7 +150,7 @@ public class MemberServiceImpl implements MemberService {
     @Override
     public UpdateResponse getUpdateInfo(Long memberId) {
 
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findActiveById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
         return UpdateResponse.from(member);
@@ -184,7 +184,7 @@ public class MemberServiceImpl implements MemberService {
 
     @Override
     public void updateAddress(Long memberId, UpdateAddressServiceRequest serviceRequest) {
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findActiveById(memberId)
                 .orElseThrow(() -> new IllegalArgumentException("유저를 찾을 수 없습니다."));
 
         member.updateAddress(serviceRequest.address());

--- a/src/main/java/team9/ddang/notification/repository/NotificationSettingsRepository.java
+++ b/src/main/java/team9/ddang/notification/repository/NotificationSettingsRepository.java
@@ -1,6 +1,10 @@
 package team9.ddang.notification.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import team9.ddang.member.entity.Member;
 import team9.ddang.notification.entity.NotificationSettings;
 import team9.ddang.notification.entity.Type;
 
@@ -9,4 +13,12 @@ import java.util.Optional;
 public interface NotificationSettingsRepository extends JpaRepository<NotificationSettings, Long> {
 
     Optional<NotificationSettings> findByMember_MemberIdAndType(Long memberId, Type type);
+
+    @Modifying
+    @Query("""
+            UPDATE NotificationSettings ns
+            SET ns.isDeleted = 'TRUE'
+            WHERE ns.member.memberId = :memberId
+            """)
+    void deleteByMember(Long memberId);
 }

--- a/src/main/java/team9/ddang/notification/service/NotificationSettingsService.java
+++ b/src/main/java/team9/ddang/notification/service/NotificationSettingsService.java
@@ -12,4 +12,6 @@ public interface NotificationSettingsService {
     SettingsUpdateResponse updateSettings(Long memberId, NotificationSettingsRequest notificationSettingsRequest);
 
     SettingsResponse getSettings(Long memberId);
+
+    void deleteNotificationSettings(Long memberId);
 }

--- a/src/main/java/team9/ddang/notification/service/NotificationSettingsServiceImpl.java
+++ b/src/main/java/team9/ddang/notification/service/NotificationSettingsServiceImpl.java
@@ -68,4 +68,9 @@ public class NotificationSettingsServiceImpl implements NotificationSettingsServ
 
         return SettingsUpdateResponse.from(notificationSettings);
     }
+
+    @Override
+    public void deleteNotificationSettings(Long memberId) {
+        notificationSettingsRepository.deleteByMember(memberId);
+    }
 }

--- a/src/main/java/team9/ddang/notification/service/response/NotificationResponse.java
+++ b/src/main/java/team9/ddang/notification/service/response/NotificationResponse.java
@@ -4,12 +4,15 @@ import team9.ddang.notification.entity.IsRead;
 import team9.ddang.notification.entity.Notification;
 import team9.ddang.notification.entity.Type;
 
+import java.time.LocalDateTime;
+
 public record NotificationResponse(
         Long notificationId,
         Type type,
         String content,
         IsRead isRead,
-        Long memberId
+        Long memberId,
+        LocalDateTime createdAt
 ) {
     public static NotificationResponse of(Notification notification) {
         return new NotificationResponse(
@@ -17,7 +20,8 @@ public record NotificationResponse(
                 notification.getType(),
                 notification.getContent(),
                 notification.getIsRead(),
-                notification.getMember().getMemberId()
+                notification.getMember().getMemberId(),
+                notification.getCreatedAt()
         );
     }
 }

--- a/src/main/java/team9/ddang/walk/repository/WalkRepository.java
+++ b/src/main/java/team9/ddang/walk/repository/WalkRepository.java
@@ -15,7 +15,7 @@ public interface WalkRepository extends JpaRepository<Walk, Long> {
     @Query("""
             SELECT COALESCE(SUM(w.totalDistance), 0)
             FROM Walk w
-            WHERE w.member.memberId = :memberId
+            WHERE w.member.memberId = :memberId AND w.isDeleted = 'FALSE'
             """)
     int findTotalDistanceByMemberId(@Param("memberId") Long memberId);
 


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- 회원 탈퇴 시 연관된 엔티티들을 같이 삭제하는 기능입니다.
- 가족의 대표일 시
   - 개인
      - NotificationSettings, Freind 삭제, RefreshToken 삭제
   - 공통
      - 기존 가족 구성원들은 가족에서 방출
      - Dog, Family 삭제
      - 본인을 포함하여 연관된 모든 가족 구성원들의 MemberDog, WalkSchedule 삭제

- 가족의 구성원일 시
   - 가족 탈퇴
   - WalkSchedule, MemberDog, Friend, NotificationSettings, RefreshToken 삭제

Friend만 물리 삭제로 구현하였고 나머지는 SoftDelete로 구현하였습니다.

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #81 

## ✅ 체크리스트
- [x] PR 제목 규칙 잘 지켰는가? 
- [x] 추가/수정사항을 설명하였는가?
- [x] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
연관된 엔티티들이 많아서 테스트를 진행할 때 꽤 힘들더군요... 테스트 코드는 내일 작성할 예정입니다.
관태님 말씀대로 회원 탈퇴로 인한 Chat 부분은 아직 건드리지 않았습니다.
나름 비즈니스 로직을 많이 고민하여 작성했는데 제가 놓친 부분이나 이상한 점이 있다면 피드백 주시면 감사하겠습니다.
개발을 하면서 제가 softDelete를 미적용 혹은 조회할 때 isDeleted를 미확인 한 경우가 많이 보여서 일단은 끊고 다음 이슈에서 진행하겠습니다.

🤔 **추후 논의할 사항**
---
- 가족 대표가 탈퇴한 경우 나머지 가족 구성원들의 유저 플로우에 대해서는 아직 정해진 게 없어서 이 부분은 추후 얘기를 나눠봐야 할 것 같습니다.
- 탈퇴 로직이 여러 엔티티들을 엮을 수 밖에 없다 보니 다른 도메인의 service, repository를 많이 참조하게 되었습니다.
- 서비스 <-> (다른 도메인) 레포지토리 보다 서비스 <-> 서비스 로 참조하는 것이 데이터 접근 로직을 배제하고 비즈니스 로직에만 집중할 수 있다고 생각하여 제가 담당한 NotificationSettings를 참조할 때는 service를 참조하게 구현하였습니다. 
다만 다른 도메인들은 기존에 작성해주신 repository 메소드를 호출하여 구현했는데 이 부분은 추후 고도화 시 저희끼리의 나름의 정책을 만들 필요가 있다고 생각합니다. 이 점에 있어서 말씀해주실 부분이 있다면 듣고싶습니다!