### PR TITLE
[Feat/#84] 채팅 데이터 분리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
     implementation 'org.thymeleaf.extras:thymeleaf-extras-springsecurity6'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+    implementation 'org.springframework.boot:spring-boot-starter-batch'
+    implementation 'org.springframework:spring-context-support'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
@@ -78,6 +80,10 @@ dependencies {
 
     // Redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+    // JAXB
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'org.glassfish.jaxb:jaxb-runtime:2.3.1'
 
     // S3
     implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'

--- a/src/main/java/team9/ddang/chat/repository/ChatRepository.java
+++ b/src/main/java/team9/ddang/chat/repository/ChatRepository.java
@@ -3,6 +3,7 @@ package team9.ddang.chat.repository;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import team9.ddang.chat.entity.Chat;
@@ -67,4 +68,8 @@ public interface ChatRepository extends JpaRepository<Chat, Long> {
       AND c.createdAt < :lastMessageCreatedAt
 """)
     Slice<Chat> findChatsBefore(@Param("chatRoomId") Long chatRoomId, @Param("lastMessageCreatedAt") LocalDateTime lastMessageCreatedAt, Pageable pageable);
+
+    @Modifying
+    @Query("DELETE FROM Chat c WHERE c.createdAt < :twoWeeksAgo")
+    void deleteChatsOlderThan(LocalDateTime twoWeeksAgo);
 }

--- a/src/main/java/team9/ddang/chat/service/ChatAdminService.java
+++ b/src/main/java/team9/ddang/chat/service/ChatAdminService.java
@@ -1,0 +1,9 @@
+package team9.ddang.chat.service;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+public interface ChatAdminService {
+    List<Map<String, String>> extractMessagesFromCsv(LocalDate startDate, LocalDate endDate, Long chatRoomId);
+}

--- a/src/main/java/team9/ddang/chat/service/ChatAdminServiceImpl.java
+++ b/src/main/java/team9/ddang/chat/service/ChatAdminServiceImpl.java
@@ -1,0 +1,112 @@
+package team9.ddang.chat.service;
+
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.ListObjectsV2Request;
+import com.amazonaws.services.s3.model.ListObjectsV2Result;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import team9.ddang.global.service.S3Service;
+import com.amazonaws.services.s3.model.S3ObjectSummary;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ChatAdminServiceImpl implements ChatAdminService {
+
+    private final S3Service s3Service;
+    private final AmazonS3Client amazonS3Client;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    public List<Map<String, String>> extractMessagesFromCsv(LocalDate startDate, LocalDate endDate, Long chatRoomId) {
+        try {
+            List<String> files = listFilesInArchiveFolder();
+
+            List<String> filteredFiles = files.stream()
+                    .filter(file -> isFileInRange(file, startDate, endDate))
+                    .toList();
+
+            List<Map<String, String>> results = new ArrayList<>();
+
+            for (String fileKey : filteredFiles) {
+                File localFile = s3Service.downloadChatFile(bucket, fileKey);
+
+                try {
+                    results.addAll(filterMessagesByChatRoomId(localFile, chatRoomId));
+                } finally {
+                    if (localFile.exists()) {
+                        localFile.delete();
+                    }
+                }
+            }
+
+            return results;
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to extract messages from S3 CSV files", e);
+        }
+    }
+
+    private List<String> listFilesInArchiveFolder() {
+        ListObjectsV2Request request = new ListObjectsV2Request()
+                .withBucketName(bucket)
+                .withPrefix("archive/");
+        ListObjectsV2Result result = amazonS3Client.listObjectsV2(request);
+
+        return result.getObjectSummaries().stream()
+                .map(S3ObjectSummary::getKey)
+                .toList();
+    }
+
+    private boolean isFileInRange(String fileName, LocalDate startDate, LocalDate endDate) {
+        try {
+            String[] parts = fileName.replace("archive/chats_archive_", "").replace(".csv", "").split("_");
+            LocalDate fileStartDate = LocalDate.parse(parts[0], DateTimeFormatter.ofPattern("yyyyMMdd"));
+            LocalDate fileEndDate = LocalDate.parse(parts[1], DateTimeFormatter.ofPattern("yyyyMMdd"));
+
+            return !(fileEndDate.isBefore(startDate) || fileStartDate.isAfter(endDate));
+        } catch (Exception e) {
+            log.error("Invalid file name format: {}", fileName, e);
+            return false;
+        }
+    }
+
+    private String getTempFilePath(String fileKey) {
+        return System.getProperty("java.io.tmpdir") + "/" + fileKey.substring(fileKey.lastIndexOf('/') + 1);
+    }
+
+    private List<Map<String, String>> filterMessagesByChatRoomId(File csvFile, Long chatRoomId) throws IOException {
+        List<Map<String, String>> results = new ArrayList<>();
+        try (BufferedReader reader = new BufferedReader(new FileReader(csvFile))) {
+            String headerLine = reader.readLine();
+            String[] headers = headerLine.split(",");
+
+            String line;
+            while ((line = reader.readLine()) != null) {
+                String[] fields = line.split(",");
+                Map<String, String> message = new HashMap<>();
+                for (int i = 0; i < headers.length; i++) {
+                    message.put(headers[i], fields[i]);
+                }
+
+                if (message.get("ChatRoomId").equals(String.valueOf(chatRoomId))) {
+                    results.add(message);
+                }
+            }
+        }
+        return results;
+    }
+}

--- a/src/main/java/team9/ddang/chat/service/ChatAdminServiceImpl.java
+++ b/src/main/java/team9/ddang/chat/service/ChatAdminServiceImpl.java
@@ -29,9 +29,6 @@ public class ChatAdminServiceImpl implements ChatAdminService {
     private final S3Service s3Service;
     private final AmazonS3Client amazonS3Client;
 
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
     public List<Map<String, String>> extractMessagesFromCsv(LocalDate startDate, LocalDate endDate, Long chatRoomId) {
         try {
             List<String> files = listFilesInArchiveFolder();
@@ -43,7 +40,7 @@ public class ChatAdminServiceImpl implements ChatAdminService {
             List<Map<String, String>> results = new ArrayList<>();
 
             for (String fileKey : filteredFiles) {
-                File localFile = s3Service.downloadChatFile(bucket, fileKey);
+                File localFile = s3Service.downloadChatFile(fileKey);
 
                 try {
                     results.addAll(filterMessagesByChatRoomId(localFile, chatRoomId));
@@ -62,7 +59,6 @@ public class ChatAdminServiceImpl implements ChatAdminService {
 
     private List<String> listFilesInArchiveFolder() {
         ListObjectsV2Request request = new ListObjectsV2Request()
-                .withBucketName(bucket)
                 .withPrefix("archive/");
         ListObjectsV2Result result = amazonS3Client.listObjectsV2(request);
 

--- a/src/main/java/team9/ddang/global/config/batch/ChatBatchConfig.java
+++ b/src/main/java/team9/ddang/global/config/batch/ChatBatchConfig.java
@@ -1,0 +1,109 @@
+package team9.ddang.global.config.batch;
+
+import jakarta.persistence.EntityManagerFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.Step;
+import org.springframework.batch.core.configuration.annotation.EnableBatchProcessing;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.item.ItemWriter;
+import org.springframework.batch.item.database.JpaPagingItemReader;
+import org.springframework.batch.item.database.builder.JpaPagingItemReaderBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.transaction.PlatformTransactionManager;
+import team9.ddang.chat.entity.Chat;
+import team9.ddang.chat.repository.ChatRepository;
+import team9.ddang.global.service.S3Service;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
+
+@Configuration
+@EnableBatchProcessing
+@RequiredArgsConstructor
+public class ChatBatchConfig {
+
+    private final EntityManagerFactory entityManagerFactory;
+    private final S3Service s3Service;
+    private final ChatRepository chatRepository;
+
+    @Value("${cloud.aws.s3.bucket}")
+    private String bucket;
+
+    @Bean
+    public Job chatArchiveJob(JobRepository jobRepository, Step chatArchiveStep) {
+        return new JobBuilder("chatArchiveJob", jobRepository)
+                .start(chatArchiveStep)
+                .build();
+    }
+
+    @Bean
+    public Step chatArchiveStep(JobRepository jobRepository, PlatformTransactionManager transactionManager) {
+        return new StepBuilder("chatArchiveStep", jobRepository)
+                .<Chat, Chat>chunk(100, transactionManager)
+                .reader(chatItemReader())
+                .writer(chatItemWriter())
+                .build();
+    }
+
+    @Bean
+    public JpaPagingItemReader<Chat> chatItemReader() {
+        return new JpaPagingItemReaderBuilder<Chat>()
+                .name("chatItemReader")
+                .entityManagerFactory(entityManagerFactory)
+                .queryString("SELECT c FROM Chat c WHERE c.createdAt < :twoWeeksAgo")
+                .parameterValues(Map.of("twoWeeksAgo", LocalDateTime.now().minusWeeks(2)))
+                .pageSize(100)
+                .build();
+    }
+
+    @Bean
+    public ItemWriter<Chat> chatItemWriter() {
+        return chunk -> {
+            List<? extends Chat> chats = chunk.getItems();
+
+            String timestamp = LocalDateTime.now().format(DateTimeFormatter.ofPattern("yyyyMMddHHmmss"));
+            String fileName = "chats_archive_" + timestamp + ".csv";
+
+            File csvFile = createCsvFile(chats, fileName);
+
+            s3Service.uploadChatFile(bucket, "archive/" + fileName, csvFile);
+
+            csvFile.delete();
+
+            chatRepository.deleteChatsOlderThan(LocalDateTime.now().minusWeeks(2));
+        };
+    }
+
+    private File createCsvFile(List<? extends Chat> chats, String filePath) throws IOException {
+        File file = new File(filePath);
+        try (var writer = new FileWriter(file)) {
+            writer.write("ID,Text,CreatedAt,ChatRoomId,MemberId,ChatType,IsRead\n");
+            for (Chat chat : chats) {
+                writer.write(String.format("%d,%s,%s,%d,%d,%s,%s\n",
+                        chat.getChatId(),
+                        sanitize(chat.getText()),
+                        chat.getCreatedAt(),
+                        chat.getChatRoom().getChatroomId(),
+                        chat.getMember().getMemberId(),
+                        chat.getChatType(),
+                        chat.getIsRead()));
+            }
+        }
+        return file;
+    }
+
+    private String sanitize(String text) {
+        if (text == null) return "";
+        return text.replaceAll(",", " ");
+    }
+}

--- a/src/main/java/team9/ddang/global/config/batch/ChatBatchConfig.java
+++ b/src/main/java/team9/ddang/global/config/batch/ChatBatchConfig.java
@@ -35,9 +35,6 @@ public class ChatBatchConfig {
     private final S3Service s3Service;
     private final ChatRepository chatRepository;
 
-    @Value("${cloud.aws.s3.bucket}")
-    private String bucket;
-
     @Bean
     public Job chatArchiveJob(JobRepository jobRepository, Step chatArchiveStep) {
         return new JobBuilder("chatArchiveJob", jobRepository)
@@ -80,7 +77,7 @@ public class ChatBatchConfig {
 
             File csvFile = createCsvFile(chats, fileName);
 
-            boolean isUploaded = s3Service.uploadChatFile(bucket, "archive/" + fileName, csvFile);
+            boolean isUploaded = s3Service.uploadChatFile("archive/" + fileName, csvFile);
             if (isUploaded) {
                 csvFile.delete();
             } else {

--- a/src/main/java/team9/ddang/global/config/batch/ChatBatchScheduler.java
+++ b/src/main/java/team9/ddang/global/config/batch/ChatBatchScheduler.java
@@ -1,0 +1,29 @@
+package team9.ddang.global.config.batch;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.batch.core.Job;
+import org.springframework.batch.core.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+public class ChatBatchScheduler {
+
+    private final JobLauncher jobLauncher;
+    private final Job chatArchiveJob;
+
+    @Scheduled(cron = "0 0 3 ? * SUN")
+    public void runChatArchiveJob() {
+        try {
+            jobLauncher.run(chatArchiveJob, new JobParametersBuilder()
+                    .addLong("time", System.currentTimeMillis())
+                    .toJobParameters());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/src/main/java/team9/ddang/global/config/batch/ChatBatchScheduler.java
+++ b/src/main/java/team9/ddang/global/config/batch/ChatBatchScheduler.java
@@ -1,6 +1,7 @@
 package team9.ddang.global.config.batch;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.batch.core.Job;
 import org.springframework.batch.core.JobParametersBuilder;
 import org.springframework.batch.core.launch.JobLauncher;
@@ -8,6 +9,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
 import org.springframework.scheduling.annotation.Scheduled;
 
+@Slf4j
 @Configuration
 @EnableScheduling
 @RequiredArgsConstructor
@@ -23,7 +25,7 @@ public class ChatBatchScheduler {
                     .addLong("time", System.currentTimeMillis())
                     .toJobParameters());
         } catch (Exception e) {
-            e.printStackTrace();
+            log.error("Batch job failed: {}", e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/team9/ddang/global/service/S3Service.java
+++ b/src/main/java/team9/ddang/global/service/S3Service.java
@@ -2,6 +2,7 @@ package team9.ddang.global.service;
 
 import com.amazonaws.services.s3.AmazonS3Client;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.GetObjectRequest;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -99,5 +100,22 @@ public class S3Service {
         }
 
         return fileName;
+    }
+
+    public void uploadChatFile(String bucketName, String keyName, File file) {
+        PutObjectRequest request = new PutObjectRequest(bucketName, keyName, file)
+                .withCannedAcl(CannedAccessControlList.Private);
+        amazonS3Client.putObject(request);
+
+        log.info("파일 업로드 성공: 버킷={}, 키={}", bucketName, keyName);
+    }
+
+    public File downloadChatFile(String bucketName, String keyName, String downloadPath) {
+        File file = new File(downloadPath);
+        GetObjectRequest request = new GetObjectRequest(bucketName, keyName);
+        amazonS3Client.getObject(request, file);
+
+        log.info("파일 다운로드 성공: 버킷={}, 키={}", bucketName, keyName);
+        return file;
     }
 }

--- a/src/main/java/team9/ddang/global/service/S3Service.java
+++ b/src/main/java/team9/ddang/global/service/S3Service.java
@@ -116,12 +116,17 @@ public class S3Service {
         }
     }
 
-    public File downloadChatFile(String bucketName, String keyName, String downloadPath) {
-        File file = new File(downloadPath);
-        GetObjectRequest request = new GetObjectRequest(bucketName, keyName);
-        amazonS3Client.getObject(request, file);
+    public File downloadChatFile(String bucketName, String keyName) {
+        try {
+            File tempFile = File.createTempFile("s3-download-", "-" + keyName.replaceAll("/", "_"));
+            GetObjectRequest request = new GetObjectRequest(bucketName, keyName);
+            amazonS3Client.getObject(request, tempFile);
 
-        log.info("파일 다운로드 성공: 버킷={}, 키={}", bucketName, keyName);
-        return file;
+            log.info("파일 다운로드 성공: 버킷={}, 키={}, 경로={}", bucketName, keyName, tempFile.getAbsolutePath());
+            return tempFile;
+        } catch (Exception e) {
+            log.error("파일 다운로드 실패: 버킷={}, 키={}, 에러={}", bucketName, keyName, e.getMessage());
+            throw new IllegalStateException("Failed to download file from S3", e);
+        }
     }
 }

--- a/src/main/java/team9/ddang/global/service/S3Service.java
+++ b/src/main/java/team9/ddang/global/service/S3Service.java
@@ -102,12 +102,18 @@ public class S3Service {
         return fileName;
     }
 
-    public void uploadChatFile(String bucketName, String keyName, File file) {
-        PutObjectRequest request = new PutObjectRequest(bucketName, keyName, file)
-                .withCannedAcl(CannedAccessControlList.Private);
-        amazonS3Client.putObject(request);
+    public boolean uploadChatFile(String bucketName, String keyName, File file) {
+        try {
+            PutObjectRequest request = new PutObjectRequest(bucketName, keyName, file)
+                    .withCannedAcl(CannedAccessControlList.Private);
+            amazonS3Client.putObject(request);
 
-        log.info("파일 업로드 성공: 버킷={}, 키={}", bucketName, keyName);
+            log.info("파일 업로드 성공: 버킷={}, 키={}", bucketName, keyName);
+            return true;
+        } catch (Exception e) {
+            log.error("파일 업로드 실패: 버킷={}, 키={}, 에러={}", bucketName, keyName, e.getMessage());
+            return false;
+        }
     }
 
     public File downloadChatFile(String bucketName, String keyName, String downloadPath) {

--- a/src/main/java/team9/ddang/global/service/S3Service.java
+++ b/src/main/java/team9/ddang/global/service/S3Service.java
@@ -102,30 +102,30 @@ public class S3Service {
         return fileName;
     }
 
-    public boolean uploadChatFile(String bucketName, String keyName, File file) {
+    public boolean uploadChatFile(String keyName, File file) {
         try {
-            PutObjectRequest request = new PutObjectRequest(bucketName, keyName, file)
+            PutObjectRequest request = new PutObjectRequest(bucket, keyName, file)
                     .withCannedAcl(CannedAccessControlList.Private);
             amazonS3Client.putObject(request);
 
-            log.info("파일 업로드 성공: 버킷={}, 키={}", bucketName, keyName);
+            log.info("파일 업로드 성공: 버킷={}, 키={}", bucket, keyName);
             return true;
         } catch (Exception e) {
-            log.error("파일 업로드 실패: 버킷={}, 키={}, 에러={}", bucketName, keyName, e.getMessage());
+            log.error("파일 업로드 실패: 버킷={}, 키={}, 에러={}", bucket, keyName, e.getMessage());
             return false;
         }
     }
 
-    public File downloadChatFile(String bucketName, String keyName) {
+    public File downloadChatFile(String keyName) {
         try {
             File tempFile = File.createTempFile("s3-download-", "-" + keyName.replaceAll("/", "_"));
-            GetObjectRequest request = new GetObjectRequest(bucketName, keyName);
+            GetObjectRequest request = new GetObjectRequest(bucket, keyName);
             amazonS3Client.getObject(request, tempFile);
 
-            log.info("파일 다운로드 성공: 버킷={}, 키={}, 경로={}", bucketName, keyName, tempFile.getAbsolutePath());
+            log.info("파일 다운로드 성공: 버킷={}, 키={}, 경로={}", bucket, keyName, tempFile.getAbsolutePath());
             return tempFile;
         } catch (Exception e) {
-            log.error("파일 다운로드 실패: 버킷={}, 키={}, 에러={}", bucketName, keyName, e.getMessage());
+            log.error("파일 다운로드 실패: 버킷={}, 키={}, 에러={}", bucket, keyName, e.getMessage());
             throw new IllegalStateException("Failed to download file from S3", e);
         }
     }


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- 매주 일요일 오전 3시에 생성된 지 1주일이 넘은 채팅 데이터를 Spring batch로 CSV 파일 변환하여 S3에 분리 저장하는 기능
- 관리자가 특정 기간에 특정 채팅방에서 발생한 채팅을 추출할 수 있는 서비스 로직


## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #84
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
일단 데이터 분리는 잘 동작하는데, 데이터 복원이 생각보다 잘 안돌아가네요.
최종 제출까지 반드시 구현되어야만 하는 기능은 아니기에 여기서 한번 끊고 새로 이슈 생성해서 해 보겠습니다.
