### PR TITLE
[Feat/#100] 메인 응답 값 변경 및 산책 로직 수정 

### DIFF
--- a/src/main/java/team9/ddang/member/service/MainServiceImpl.java
+++ b/src/main/java/team9/ddang/member/service/MainServiceImpl.java
@@ -38,10 +38,10 @@ public class MainServiceImpl implements MainService{
         long totalDistanceMeter = walkSummary.get("totalDistanceMeter");
 
         if (walkMember == null) {
-            return MainResponse.of(dog, totalSeconds, (int) totalDistanceMeter);
+            return MainResponse.of(dog, totalSeconds, (int) totalDistanceMeter, member);
         }
 
-        return MainResponse.of(walkMember, dog, totalSeconds, (int) totalDistanceMeter);
+        return MainResponse.of(walkMember, dog, totalSeconds, (int) totalDistanceMeter, member);
     }
 
     private Map<String, Long> calculateWalkSummary(Long dogId) {

--- a/src/main/java/team9/ddang/member/service/response/MainResponse.java
+++ b/src/main/java/team9/ddang/member/service/response/MainResponse.java
@@ -2,24 +2,42 @@ package team9.ddang.member.service.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import team9.ddang.dog.entity.Dog;
+import team9.ddang.global.entity.Gender;
 import team9.ddang.member.entity.FamilyRole;
 import team9.ddang.member.entity.Member;
+import team9.ddang.member.entity.Provider;
 import team9.ddang.walk.service.response.TimeDuration;
 import team9.ddang.walk.util.WalkCalculator;
 
 @Schema(description = "Main 화면 응답")
 public record MainResponse(
-        @Schema(description = "산책 나갈 회원 ID", example = "1")
+        @Schema(description = "회원 ID", example = "1")
         Long memberId,
 
-        @Schema(description = "산책 나갈 가족 역할")
+        @Schema(description = "가족 역할", example = "ELDER_BROTHER")
         FamilyRole familyRole,
+
+        @Schema(description = "주소", example = "인천광역시")
+        String address,
+
+        @Schema(description = "이메일", example = "example@example.com")
+        String email,
+
+        @Schema(description = "성별", example = "MALE")
+        Gender memberGender,
+
+        @Schema(description = "멤버 이름", example = "춘식이")
+        String memberName,
+
+        @Schema(description = "멤버 프로필 이미지", example = "https://example.com/profile.jpg")
+        String memberProfileImgUrl,
+
+        @Schema(description = "멤버 SNS", example = "KAKAO")
+        Provider provider,
 
         @Schema(description = "강아지 이름", example = "Buddy")
         String dogName,
 
-        @Schema(description = "멤버 프로필 이미지", example = "Avatar4.svg")
-        String memberProfileImgUrl,
 
         @Schema(description = "산책 시간")
         TimeDuration timeDuration,
@@ -30,21 +48,31 @@ public record MainResponse(
         @Schema(description = "총 소비 칼로리", example = "50")
         int totalCalorie
 ) {
-    public static MainResponse of(Member member, Dog dog, long totalSeconds, int totalDistanceMeter){
-        return new MainResponse(member.getMemberId(),
-                member.getFamilyRole(),
+    public static MainResponse of(Member member, Dog dog, long totalSeconds, int totalDistanceMeter, Member loginMember){
+        return new MainResponse(loginMember.getMemberId(),
+                loginMember.getFamilyRole(),
+                loginMember.getAddress(),
+                loginMember.getEmail(),
+                loginMember.getGender(),
+                loginMember.getName(),
+                loginMember.getProfileImg(),
+                loginMember.getProvider(),
                 dog.getName(),
-                member.getProfileImg(),
                 team9.ddang.walk.service.response.TimeDuration.from(totalSeconds),
                 totalDistanceMeter,
                 WalkCalculator.calculateCalorie(dog.getWeight(), totalDistanceMeter));
     }
 
-    public static MainResponse of(Dog dog, long totalSeconds, int totalDistanceMeter){
-        return new MainResponse(0L,
-                null,
+    public static MainResponse of(Dog dog, long totalSeconds, int totalDistanceMeter,  Member loginMember){
+        return new MainResponse(          loginMember.getMemberId(),
+                loginMember.getFamilyRole(),
+                loginMember.getAddress(),
+                loginMember.getEmail(),
+                loginMember.getGender(),
+                loginMember.getName(),
+                loginMember.getProfileImg(),
+                loginMember.getProvider(),
                 dog.getName(),
-                dog.getProfileImg(),
                 team9.ddang.walk.service.response.TimeDuration.from(totalSeconds),
                 totalDistanceMeter,
                 WalkCalculator.calculateCalorie(dog.getWeight(), totalDistanceMeter));

--- a/src/main/java/team9/ddang/walk/service/WalkLocationServiceImpl.java
+++ b/src/main/java/team9/ddang/walk/service/WalkLocationServiceImpl.java
@@ -58,7 +58,7 @@ public class WalkLocationServiceImpl implements WalkLocationService {
         ProposalWalkResponse response = ProposalWalkResponse.of(dog, member, proposalWalkServiceRequest.comment());
 
         sendMessageToWalkUrl(otherEmail, response);
-        sendMessageToWalkUrl(member.getEmail(), response);
+        sendMessageToWalkUrl(member.getEmail(), "Proposal Success");
     }
 
     @Override

--- a/src/main/java/team9/ddang/walk/service/WalkLocationServiceImpl.java
+++ b/src/main/java/team9/ddang/walk/service/WalkLocationServiceImpl.java
@@ -15,12 +15,16 @@ import team9.ddang.global.service.RedisService;
 import team9.ddang.member.entity.IsMatched;
 import team9.ddang.member.entity.Member;
 import team9.ddang.member.repository.MemberRepository;
+import team9.ddang.walk.entity.Location;
+import team9.ddang.walk.entity.Position;
+import team9.ddang.walk.repository.LocationRepository;
 import team9.ddang.walk.service.request.walk.DecisionWalkServiceRequest;
 import team9.ddang.walk.service.request.walk.ProposalWalkServiceRequest;
 import team9.ddang.walk.service.request.walk.StartWalkServiceRequest;
 import team9.ddang.walk.service.response.walk.*;
 
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -35,6 +39,7 @@ public class WalkLocationServiceImpl implements WalkLocationService {
     private final MemberDogRepository memberDogRepository;
     private final SimpMessagingTemplate messagingTemplate;
     private final MemberRepository memberRepository;
+    private final LocationRepository locationRepository;
 
 
     @Override
@@ -111,6 +116,7 @@ public class WalkLocationServiceImpl implements WalkLocationService {
         List<String> memberEmailList = getEmailListFromNearbyMemberResults(results, email);
 
         if(memberEmailList.isEmpty()){
+            sendMessageToWalkUrl(email, null);
             return;
         }
 
@@ -164,5 +170,17 @@ public class WalkLocationServiceImpl implements WalkLocationService {
             throw new IllegalArgumentException(ALREADY_MATCHED_MEMBER.getText());
         }
 
+    }
+
+    private void saveMemberLocationAtRDB(String email, StartWalkServiceRequest startWalkServiceRequest){
+        Location location = Location.builder()
+                .position(Position.builder()
+                        .timeStamp(LocalDateTime.now())
+                        .latitude(startWalkServiceRequest.latitude())
+                        .longitude(startWalkServiceRequest.longitude())
+                        .build())
+                .build();
+
+        locationRepository.save(location);
     }
 }

--- a/src/main/java/team9/ddang/walk/service/WalkLocationServiceImpl.java
+++ b/src/main/java/team9/ddang/walk/service/WalkLocationServiceImpl.java
@@ -1,6 +1,7 @@
 package team9.ddang.walk.service;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.geo.GeoResult;
 import org.springframework.data.geo.GeoResults;
 import org.springframework.data.geo.Point;
@@ -15,16 +16,12 @@ import team9.ddang.global.service.RedisService;
 import team9.ddang.member.entity.IsMatched;
 import team9.ddang.member.entity.Member;
 import team9.ddang.member.repository.MemberRepository;
-import team9.ddang.walk.entity.Location;
-import team9.ddang.walk.entity.Position;
-import team9.ddang.walk.repository.LocationRepository;
 import team9.ddang.walk.service.request.walk.DecisionWalkServiceRequest;
 import team9.ddang.walk.service.request.walk.ProposalWalkServiceRequest;
 import team9.ddang.walk.service.request.walk.StartWalkServiceRequest;
 import team9.ddang.walk.service.response.walk.*;
 
 import java.time.Duration;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -33,13 +30,13 @@ import static team9.ddang.walk.service.RedisKey.*;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class WalkLocationServiceImpl implements WalkLocationService {
 
     private final RedisService redisService;
     private final MemberDogRepository memberDogRepository;
     private final SimpMessagingTemplate messagingTemplate;
     private final MemberRepository memberRepository;
-    private final LocationRepository locationRepository;
 
 
     @Override
@@ -149,6 +146,7 @@ public class WalkLocationServiceImpl implements WalkLocationService {
 
     private void sendMessageToWalkUrl(String email, Object data){
         messagingTemplate.convertAndSend("/sub/walk/" + email,  WebSocketResponse.ok(data));
+        log.info("Message sent to /sub/walk/" + email + " with data: " + data);
     }
 
     private Member getMemberFromEmailOrElseThrow(String email){
@@ -170,17 +168,5 @@ public class WalkLocationServiceImpl implements WalkLocationService {
             throw new IllegalArgumentException(ALREADY_MATCHED_MEMBER.getText());
         }
 
-    }
-
-    private void saveMemberLocationAtRDB(String email, StartWalkServiceRequest startWalkServiceRequest){
-        Location location = Location.builder()
-                .position(Position.builder()
-                        .timeStamp(LocalDateTime.now())
-                        .latitude(startWalkServiceRequest.latitude())
-                        .longitude(startWalkServiceRequest.longitude())
-                        .build())
-                .build();
-
-        locationRepository.save(location);
     }
 }


### PR DESCRIPTION
## 📢 기능 설명 
<!-- 필요시 실행결과 스크린샷 첨부 -->
- 근처에 산책 중인 강아지가 없더라도 메시지를 보내도록 변경
- MainReponse 에 로그인한 유저 정보가 포함되도록 변경

## 연결된 issue
<!-- 연결된 issue를 자동을 닫기 위해 아래 {이슈넘버}를 입력해주세요. -->
- close #100 
<br>

## ✅ 체크리스트
- [ ] PR 제목 규칙 잘 지켰는가? 
- [ ] 추가/수정사항을 설명하였는가?
- [ ] 이슈넘버를 적었는가?



📣 **To Reviewers**
---
<!-- 전달사항 -->
원래 피그마나 기능상 메인에는 오늘 산책 예정인 가족의 역할이 나오도록 되어있었던 거 같은데,
일단 로그인한 유저의 정보만 모두 보내달라고 하셔서 수정하였습니다. 근데 뭔가 나중에 또 산책 예정인 유저에 대한 조회가 필요할 거 같아서 일단 냅뒀습니다.

